### PR TITLE
fix(cli): stop read autocomplete when attribute arg is already filled

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -1182,6 +1182,9 @@ func registerShorthandClusters() {
 			Short: fmt.Sprintf("Read a %s attribute", clCopy.DisplayName),
 			Args:  cobra.ExactArgs(1),
 			ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+				if len(args) >= 1 {
+					return nil, cobra.ShellCompDirectiveNoFileComp
+				}
 				results := clusters.Global.SearchAttributes(clCopy.ID, toComplete)
 				names := make([]string, len(results))
 				for i, a := range results {


### PR DESCRIPTION
## Summary
- Adds `if len(args) >= 1` guard to `readCmd.ValidArgsFunction` in `cli/cluster.go`
- Mirrors the same pattern already used by the `write` subcommand
- No completions are offered once the attribute argument is filled

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)