### PR TITLE
feat: Improve support on-network commissioning for IP-discovered devices

### DIFF
--- a/cli/commission.go
+++ b/cli/commission.go
@@ -269,9 +269,10 @@ func newCommissionIPCmd() *cobra.Command {
 			}
 
 			params := commissioning.CommissioningParams{
-				Passcode: pin,
-				NodeID:   nodeID,
-				Network:  network,
+				Passcode:  pin,
+				NodeID:    nodeID,
+				Network:   network,
+				OnNetwork: true,
 			}
 
 			stepper.Step(fmt.Sprintf("Commissioning device at %s with pin %s as node %s",

--- a/internal/commissioning/flow.go
+++ b/internal/commissioning/flow.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/p0fi/matter-cli/internal/interaction"
@@ -34,6 +35,10 @@ type CommissioningParams struct {
 	// Network holds optional network credentials for WiFi or Thread provisioning.
 	// If nil, the device is assumed to be on an Ethernet network.
 	Network *NetworkCredentials
+	// OnNetwork indicates the device is already reachable over IP (e.g. mDNS
+	// discovery or static address). When true, network provisioning steps are
+	// skipped regardless of the device's reported NetworkCommissioning capabilities.
+	OnNetwork bool
 	// FailsafeSeconds is the failsafe timer duration. Defaults to 60 if zero.
 	FailsafeSeconds uint16
 }
@@ -227,6 +232,14 @@ func (c *Commissioner) Commission(ctx context.Context, params CommissioningParam
 		return nil, fmt.Errorf("commissioning: discovering device: %w", err)
 	}
 
+	// If the device was discovered via IP (not BLE), it is already on the
+	// network. This overrides any device-reported NetworkCommissioning
+	// capabilities that might incorrectly claim Thread/WiFi-only support.
+	if !params.OnNetwork && !strings.HasPrefix(addr, "ble://") {
+		params.OnNetwork = true
+		slog.Debug("commissioning: device discovered via IP — marking as on-network")
+	}
+
 	// Step 3: Establish PASE session.
 	c.reportProgress(StepEstablishPASE)
 	paseSession, err := c.Sessions.EstablishPASE(ctx, addr, passcode)
@@ -277,11 +290,19 @@ func (c *Commissioner) Commission(ctx context.Context, params CommissioningParam
 	//   Bit 1 (0x02): Thread
 	//   Bit 2 (0x04): Ethernet
 	//
+	// If the device is already on-network and the user supplied credentials,
+	// warn and discard them — network provisioning is unnecessary.
+	if params.OnNetwork && params.Network != nil {
+		slog.Warn("commissioning: device is already on-network; ignoring supplied network credentials",
+			"networkType", params.Network.Type.String())
+		params.Network = nil
+	}
+
 	// If the device only supports Thread (or only Wi-Fi) and no matching
 	// credentials were supplied, bail out now with a clear error message
 	// instead of proceeding to AddNOC where the BLE connection would drop
 	// and leave the user with a cryptic timeout.
-	if params.Network == nil {
+	if params.Network == nil && !params.OnNetwork {
 		if featureData, rdErr := c.Client.ReadAttribute(ctx, paseSession, 0, 0x0031, 0xFFFC); rdErr == nil {
 			features := decodeTLVUint32(featureData)
 			hasWiFi := features&0x01 != 0

--- a/internal/commissioning/flow_test.go
+++ b/internal/commissioning/flow_test.go
@@ -519,6 +519,8 @@ func TestParseSetupCode(t *testing.T) {
 
 func TestCommissioner_Commission_ThreadDeviceNoCredentials(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery so the device is NOT on-network.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// Override the NetworkCommissioning FeatureMap (cluster 0x0031, attr 0xFFFC)
 	// to report Thread-only (bit 1 = 0x02).
@@ -558,6 +560,8 @@ func TestCommissioner_Commission_ThreadDeviceNoCredentials(t *testing.T) {
 
 func TestCommissioner_Commission_WiFiThreadDeviceNoCredentials(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery so the device is NOT on-network.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// FeatureMap: WiFi (0x01) + Thread (0x02) = 0x03
 	mc := c.Client.(*mockInteractionClient)
@@ -621,8 +625,75 @@ func TestCommissioner_Commission_EthernetDeviceNoCredentials(t *testing.T) {
 	}
 }
 
+// TestCommissioner_Commission_OnNetworkSkipsFeatureMapCheck verifies that when
+// a device is discovered via IP (on-network), the commissioning flow skips the
+// NetworkCommissioning FeatureMap validation — even if the device incorrectly
+// reports Thread-only capabilities.
+func TestCommissioner_Commission_OnNetworkThreadDeviceNoCredentials(t *testing.T) {
+	c := newTestCommissioner()
+	// Default mock discoverer returns an IP address → auto-detected as on-network.
+
+	// FeatureMap: Thread-only (0x02) — would normally require credentials,
+	// but the device is on-network so this should be ignored.
+	mc := c.Client.(*mockInteractionClient)
+	mc.readOverrides = map[attrKey]struct {
+		data []byte
+		err  error
+	}{
+		{endpoint: 0, cluster: 0x0031, attribute: 0xFFFC}: {
+			data: encodeTLVUint32(0x02), // Thread only
+		},
+	}
+
+	payload := SetupPayload{
+		Discriminator: 3840,
+		Passcode:      20202021,
+	}
+	qr, _ := payload.QRCode()
+
+	params := CommissioningParams{
+		SetupCode: qr,
+		NodeID:    1,
+		// No Network credentials — device is on-network, so none needed.
+	}
+
+	// On-network device should succeed even with Thread-only FeatureMap.
+	if _, err := c.Commission(context.Background(), params); err != nil {
+		t.Fatalf("Commission should succeed for on-network device with Thread FeatureMap: %v", err)
+	}
+}
+
+// TestCommissioner_Commission_OnNetworkIgnoresSuppliedCredentials verifies that
+// when a device is on-network and the user supplies WiFi credentials, the
+// credentials are ignored (with a warning) and commissioning succeeds without
+// network provisioning.
+func TestCommissioner_Commission_OnNetworkIgnoresSuppliedCredentials(t *testing.T) {
+	c := newTestCommissioner()
+	// Default mock discoverer returns an IP address → auto-detected as on-network.
+
+	payload := SetupPayload{
+		Discriminator: 3840,
+		Passcode:      20202021,
+	}
+	qr, _ := payload.QRCode()
+
+	wifiCreds := NewWiFiCredentials("TestNet", "TestPass")
+	params := CommissioningParams{
+		SetupCode: qr,
+		NodeID:    1,
+		Network:   &wifiCreds,
+	}
+
+	// Should succeed — credentials are ignored for on-network devices.
+	if _, err := c.Commission(context.Background(), params); err != nil {
+		t.Fatalf("Commission should succeed (ignoring creds) for on-network device: %v", err)
+	}
+}
+
 func TestCommissioner_Commission_ThreadDeviceWithCredentials(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery — credentials are provided for the Thread network.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// FeatureMap: Thread-only (0x02) — but credentials ARE provided.
 	mc := c.Client.(*mockInteractionClient)
@@ -659,6 +730,8 @@ func TestCommissioner_Commission_ThreadDeviceWithCredentials(t *testing.T) {
 // the commissioner reconnects BLE and delivers the Thread dataset.
 func TestCommissioner_Commission_BLEDropDuringAddNOC_WithThread(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery — Thread credentials need to be delivered over BLE.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// Make InvokeTimed fail with ErrConnClosed on the 2nd call.
 	// Call order: 1=AddTrustedRoot (TimedInvoke), 2=AddNOC (TimedInvoke).
@@ -706,6 +779,8 @@ func TestCommissioner_Commission_BLEDropDuringAddNOC_WithThread(t *testing.T) {
 // returns an error explaining that the Thread dataset could not be delivered.
 func TestCommissioner_Commission_BLEDropDuringAddNOC_ReconnectFails(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery — Thread credentials need to be delivered over BLE.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// Make InvokeTimed fail with ErrConnClosed on the 2nd call (AddNOC).
 	mc := c.Client.(*mockInteractionClient)
@@ -749,6 +824,8 @@ func TestCommissioner_Commission_BLEDropDuringAddNOC_ReconnectFails(t *testing.T
 // reconnect logic works for WiFi devices (not just Thread).
 func TestCommissioner_Commission_BLEDropDuringAddNOC_WithWiFi(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery — WiFi credentials need to be delivered over BLE.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// Make InvokeTimed fail with ErrConnClosed on the 2nd call (AddNOC).
 	mc := c.Client.(*mockInteractionClient)
@@ -926,6 +1003,8 @@ func TestCommissioner_Commission_NonConcurrentDevice(t *testing.T) {
 // after AddNOC drops BLE, and commissioning succeeds.
 func TestCommissioner_Commission_NonConcurrentDeviceWithThread(t *testing.T) {
 	c := newTestCommissioner()
+	// Simulate BLE discovery — Thread credentials need to be delivered over BLE.
+	c.Discoverer = &mockDiscoverer{addr: "ble://mock"}
 
 	// SupportsConcurrentConnection = false
 	w := tlv.NewWriter()


### PR DESCRIPTION
This pull request improves the commissioning flow for Matter devices by making the handling of "on-network" devices (those already reachable over IP) more robust and user-friendly. The changes ensure that network provisioning steps are skipped when unnecessary, user-supplied credentials are ignored with a warning when not needed, and the logic is thoroughly tested for both BLE and IP discovery scenarios.

Key improvements include:

**Commissioning flow enhancements:**

* Added an `OnNetwork` flag to `CommissioningParams` and logic to automatically set it when a device is discovered via IP, ensuring network provisioning is skipped for devices already on the network. [[1]](diffhunk://#diff-50ed0a7c3591135460c3a878b3f5d5b4a4862359a61980bdfabcb4d45caad440R38-R41) [[2]](diffhunk://#diff-50ed0a7c3591135460c3a878b3f5d5b4a4862359a61980bdfabcb4d45caad440R235-R242) [[3]](diffhunk://#diff-46edfa18488adc829ce8f3dac8171765f240e3b7d79539eb9926cc20445430fdR275)
* Modified commissioning logic to ignore and warn about user-supplied network credentials when the device is already on-network, preventing unnecessary provisioning steps.

**Testing improvements:**

* Added new tests to verify that on-network devices skip network provisioning, ignore supplied credentials, and succeed even if the device incorrectly reports Thread-only capabilities.
* Updated existing tests to explicitly simulate BLE discovery (not on-network) by setting the discoverer address to a BLE URI, ensuring correct test coverage for both BLE and IP discovery paths. [[1]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R522-R523) [[2]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R563-R564) [[3]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R733-R734) [[4]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R782-R783) [[5]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R827-R828) [[6]](diffhunk://#diff-bba0aac514c00e6216b5de8460fa92dc0af724ec867370a131fe410d62e4b0c6R1006-R1007)

**Minor code maintenance:**

* Added the `strings` import to support address prefix checks.