### PR TITLE
fix: set LastSeen on commissioning and successful CASE session

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/p0fi/matter-cli/cli/completion"
 	"github.com/p0fi/matter-cli/cli/output"
@@ -203,6 +204,11 @@ func connectToNode(ctx context.Context, nodeID uint64) (
 		ctrl.Close()
 		s.Close()
 		return nil, nil, nil, fmt.Errorf("establishing CASE session to node %d: %w", nodeID, err)
+	}
+
+	node.LastSeen = time.Now()
+	if saveErr := s.SaveNode(fabricID, node); saveErr != nil {
+		slog.Warn("failed to update LastSeen", "node", nodeID, "err", saveErr)
 	}
 
 	client := interaction.NewClient(ctrl.Exchanges())

--- a/cli/commission.go
+++ b/cli/commission.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/p0fi/matter-cli/cli/output"
 	"github.com/p0fi/matter-cli/internal/clusters"
@@ -339,6 +340,7 @@ func buildNodeFromResult(nodeID uint64, result *commissioning.CommissioningResul
 		VendorID:    result.VendorID,
 		ProductID:   result.ProductID,
 		LastAddress: result.Address,
+		LastSeen:    time.Now(),
 	}
 	if result.ProductName != "" {
 		node.Name = result.ProductName

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -394,6 +394,11 @@ func (s *Server) getOrCreateSession(ctx context.Context, nodeID, fabricID uint64
 		return nil, nil, fmt.Errorf("establishing CASE session to node %d: %w", nodeID, err)
 	}
 
+	node.LastSeen = time.Now()
+	if saveErr := s.store.SaveNode(fabricID, node); saveErr != nil {
+		slog.Warn("daemon: failed to update LastSeen", "node", nodeID, "err", saveErr)
+	}
+
 	client := interaction.NewClient(ctrl.Exchanges())
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

- `Node.LastSeen` was never written anywhere, causing `matter fabric ls` to always display `never` in the `LAST SEEN` column
- Set `LastSeen: time.Now()` in `buildNodeFromResult` at commissioning time
- Update `node.LastSeen` and call `SaveNode` after every successful `ConnectCASE` in both the CLI path (`connectToNode`) and the daemon path (`getOrCreateSession`)

## Test plan

- [ ] Commission a device and verify `matter fabric ls` shows a recent timestamp instead of `never`
- [ ] Run a cluster command against a commissioned device and verify `LAST SEEN` updates
- [ ] Verify `mise run test` passes (pre-existing failures in `internal/transport` and `internal/interaction` are unrelated)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)