### PR TITLE
feat: add GoReleaser with Homebrew tap auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --split --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-darwin
+          path: dist/
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --split --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-linux
+          path: dist/
+
+  release:
+    needs: [build-darwin, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          path: dist/
+          merge-multiple: true
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: continue --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   build-darwin:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist-darwin
           path: dist/
@@ -36,15 +36,15 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --split --clean
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist-linux
           path: dist/
@@ -61,17 +61,17 @@ jobs:
     needs: [build-darwin, build-linux]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           path: dist/
           merge-multiple: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: continue --merge

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: matter
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: matter-darwin
+    main: ./cmd/matter/
+    binary: matter
+    goos: [darwin]
+    goarch: [amd64, arm64]
+    env:
+      - CGO_ENABLED=1
+    ldflags:
+      - -s -w
+      - -X github.com/p0fi/matter-cli/cli.version={{.Version}}
+      - -X github.com/p0fi/matter-cli/cli.commit={{.ShortCommit}}
+      - -X github.com/p0fi/matter-cli/cli.date={{.Date}}
+
+  - id: matter-linux
+    main: ./cmd/matter/
+    binary: matter
+    goos: [linux]
+    goarch: [amd64, arm64]
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/p0fi/matter-cli/cli.version={{.Version}}
+      - -X github.com/p0fi/matter-cli/cli.commit={{.ShortCommit}}
+      - -X github.com/p0fi/matter-cli/cli.date={{.Date}}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - Merge pull request
+      - Merge branch
+
+brews:
+  - name: matter-cli
+    repository:
+      owner: p0fi
+      name: homebrew-tools
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: "https://github.com/p0fi/matter-cli"
+    description: "Matter protocol CLI controller — commission and control Matter devices from your terminal"
+    license: "Apache-2.0"
+    install: |
+      bin.install "matter"
+    test: |
+      system "#{bin}/matter", "version"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26.2"
 "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "latest"
+"go:github.com/goreleaser/goreleaser/v2" = "latest"
 
 [env]
 BINARY = "matter"
@@ -55,3 +56,7 @@ run = "gofmt -w ."
 [tasks.clean]
 description = "Remove build artifacts"
 run = "rm -rf bin/ coverage.out coverage.html"
+
+[tasks.release-dry-run]
+description = "Dry-run a release build locally (snapshot, no publish)"
+run = "goreleaser release --snapshot --clean"


### PR DESCRIPTION
## Summary
- Adds `.goreleaser.yaml` with split builds: darwin (CGO=1 for CoreBluetooth) and linux (CGO=0)
- Adds `.github/workflows/release.yml` that runs darwin on `macos-latest`, linux on `ubuntu-latest`, then merges and publishes
- Updates `mise.toml` with goreleaser tool and `mise run release-dry-run` task

## Setup required before first release
1. Create GitHub repo `p0fi/homebrew-tools` (public or private)
2. Add repo secret `HOMEBREW_TAP_GITHUB_TOKEN` — a classic PAT with `repo` scope so CI can push the formula

## How to release
```sh
git tag v0.1.0
git push origin v0.1.0
```
CI builds, creates a GitHub release, and commits `Formula/matter-cli.rb` to the tap.

## Colleagues install with
```sh
brew tap p0fi/tools
brew install matter-cli
```

## Pre-existing failures (not introduced by this PR)
- **lint**: deprecated `elliptic.Marshal/Unmarshal`, gosimple loop suggestions, unchecked `rand.Read`
- **test**: race in `TestBLEConn_DisconnectWatcherDetectsDisconnection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)