### PR TITLE
feat: Warn when macOS Matter BLE developer profile is missing

### DIFF
--- a/cli/ble_profile_check.go
+++ b/cli/ble_profile_check.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os/exec"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -68,22 +67,9 @@ func isMatterBLEProfileInstalled() (bool, error) {
 		return false, fmt.Errorf("running system_profiler: %w", err)
 	}
 
-	// The profile's display name or identifier typically contains "Matter"
-	// and "Bluetooth". Check for common substrings that would appear in the
-	// profile metadata. The canonical profile is named
-	// "EnableBluetoothCentralMatterClientDeveloperMode".
+	// Match against the canonical profile identifier. Using a broad
+	// multi-keyword check risks false positives when unrelated profiles
+	// mention "matter" or "bluetooth" independently.
 	lower := bytes.ToLower(out)
-	hasMatter := bytes.Contains(lower, []byte("matter"))
-	hasBluetooth := bytes.Contains(lower, []byte("bluetooth"))
-
-	if hasMatter && hasBluetooth {
-		return true, nil
-	}
-
-	// Also check for the canonical identifier substring.
-	if strings.Contains(string(lower), "enablebluetoothcentralmatterclientdevelopermode") {
-		return true, nil
-	}
-
-	return false, nil
+	return bytes.Contains(lower, []byte("enablebluetoothcentralmatterclientdevelopermode")), nil
 }

--- a/cli/ble_profile_check.go
+++ b/cli/ble_profile_check.go
@@ -1,0 +1,89 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/p0fi/matter-cli/cli/output"
+)
+
+var (
+	bleProfileOnce      sync.Once
+	bleProfileInstalled bool
+	bleProfileCheckDone bool // true if the check completed without error
+)
+
+// warnIfMissingBLEProfile checks whether the macOS Bluetooth Central Matter
+// Client Developer Mode profile is installed. If the profile is missing, a
+// warning is printed to w explaining how to install it. On non-macOS systems
+// this is a no-op. The result is cached so the system_profiler command runs
+// at most once per process.
+func warnIfMissingBLEProfile(w io.Writer) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+
+	bleProfileOnce.Do(func() {
+		installed, err := isMatterBLEProfileInstalled()
+		if err != nil {
+			// Could not determine — don't warn.
+			return
+		}
+		bleProfileInstalled = installed
+		bleProfileCheckDone = true
+	})
+
+	if !bleProfileCheckDone || bleProfileInstalled {
+		return
+	}
+
+	fmt.Fprintf(w, "\n%s The macOS Bluetooth Central Matter Client Developer Mode profile does not appear to be installed.\n", output.WarningIcon())
+	fmt.Fprintln(w, output.Muted("  BLE operations with Matter devices require this profile."))
+	fmt.Fprintln(w, output.Muted("  Install via: System Settings → Privacy & Security → Profiles"))
+	fmt.Fprintln(w, output.Muted("  Download:    https://developer.apple.com/services-account/download?path=/iOS/iOS_Logs/EnableBluetoothCentralMatterClientDeveloperMode.mobileconfig"))
+	fmt.Fprintln(w)
+}
+
+// isMatterBLEProfileInstalled uses system_profiler to check whether any
+// installed configuration profile looks like the Matter BLE developer profile.
+// Returns (true, nil) if found, (false, nil) if definitely not found, or
+// (false, err) if the check itself failed.
+func isMatterBLEProfileInstalled() (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "system_profiler", "SPConfigurationProfileDataType")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("running system_profiler: %w", err)
+	}
+
+	// The profile's display name or identifier typically contains "Matter"
+	// and "Bluetooth". Check for common substrings that would appear in the
+	// profile metadata. The canonical profile is named
+	// "EnableBluetoothCentralMatterClientDeveloperMode".
+	lower := bytes.ToLower(out)
+	hasMatter := bytes.Contains(lower, []byte("matter"))
+	hasBluetooth := bytes.Contains(lower, []byte("bluetooth"))
+
+	if hasMatter && hasBluetooth {
+		return true, nil
+	}
+
+	// Also check for the canonical identifier substring.
+	if strings.Contains(string(lower), "enablebluetoothcentralmatterclientdevelopermode") {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/cli/ble_profile_check_test.go
+++ b/cli/ble_profile_check_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+)
+
+func TestWarnIfMissingBLEProfile_NonDarwin(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("this test validates the no-op path on non-darwin")
+	}
+
+	var buf bytes.Buffer
+	warnIfMissingBLEProfile(&buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on non-darwin, got: %s", buf.String())
+	}
+}
+
+func TestWarnIfMissingBLEProfile_Darwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+
+	// This test verifies the function runs without panicking on macOS.
+	// The actual output depends on whether the profile is installed,
+	// which varies by machine — so we just confirm no crash.
+	var buf bytes.Buffer
+	warnIfMissingBLEProfile(&buf)
+
+	// The function should either produce no output (profile installed or
+	// check failed) or produce a warning containing "profile".
+	if buf.Len() > 0 && !bytes.Contains(bytes.ToLower(buf.Bytes()), []byte("profile")) {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}

--- a/cli/commission_ble.go
+++ b/cli/commission_ble.go
@@ -103,7 +103,12 @@ func runCommissionBLE(cmd *cobra.Command, args []string) error {
 	}
 	defer ctrl.Close()
 
+	warnIfMissingBLEProfile(cmd.ErrOrStderr())
+
 	adapter := transport.NewDefaultBLEAdapter()
+	if err := adapter.Enable(); err != nil {
+		return fmt.Errorf("enabling BLE adapter: %w\n\nMake sure Bluetooth is enabled and the application has permission to use it.", err)
+	}
 
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	stepper := output.NewStepper(cmd.OutOrStdout(), verbose)
@@ -211,7 +216,12 @@ func runCommissionBLEAddress(cmd *cobra.Command, args []string) error {
 	}
 	defer ctrl.Close()
 
+	warnIfMissingBLEProfile(cmd.ErrOrStderr())
+
 	adapter := transport.NewDefaultBLEAdapter()
+	if err := adapter.Enable(); err != nil {
+		return fmt.Errorf("enabling BLE adapter: %w\n\nMake sure Bluetooth is enabled and the application has permission to use it.", err)
+	}
 	bleAddr := transport.BLEAddress(args[0])
 
 	verbose, _ := cmd.Flags().GetBool("verbose")

--- a/cli/discover_ble.go
+++ b/cli/discover_ble.go
@@ -69,6 +69,8 @@ Platform requirements:
 			timeout, _ := cmd.Flags().GetDuration("timeout")
 			raw, _ := cmd.Flags().GetBool("raw")
 
+			warnIfMissingBLEProfile(cmd.ErrOrStderr())
+
 			adapter := transport.NewDefaultBLEAdapter()
 			if err := adapter.Enable(); err != nil {
 				return fmt.Errorf("enabling BLE adapter: %w\n\nMake sure Bluetooth is enabled and the application has permission to use it.", err)


### PR DESCRIPTION
## Summary

- Adds a pre-flight check before any BLE operation (`discover ble`, `commission ble`, `commission ble-address`) that detects whether the macOS Bluetooth Central Matter Client Developer Mode profile is installed
- Uses `system_profiler SPConfigurationProfileDataType` with a 10s timeout, result cached via `sync.Once` (runs at most once per process)
- If missing, prints a warning to stderr with download URL and install instructions
- No-op on non-macOS systems

Without this profile, CoreBluetooth silently restricts access to the Matter BLE service UUID (0xFFF6), causing cryptic BLE failures that are hard to diagnose.

## Test plan

- [x] `mise run lint` passes
- [x] `mise run build` passes
- [x] New unit tests pass (`TestWarnIfMissingBLEProfile_Darwin`, `TestWarnIfMissingBLEProfile_NonDarwin`)
- [x] Run `matter discover ble` on a Mac without the profile → warning appears
- [x] Install the profile, run again → no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)