### PR TITLE
feat: Add `matter fabric reset` to remove all devices at once

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ matter commission ip 192.168.1.42 --setup-code 34970112332
 matter fabric ls
 matter @1 tree                  # show endpoints & clusters
 matter @1 tree -L 4             # full tree including attribute values
+matter fabric reset             # remove all devices (interactive prompt)
+matter fabric reset --yes       # skip confirmation (for scripts/CI)
 
 # Set a sticky default target (node/endpoint)
 matter use @1/1

--- a/cli/device.go
+++ b/cli/device.go
@@ -44,6 +44,22 @@ func openStoreForCompletion() (store.Store, error) {
 	return s, nil
 }
 
+// listNodes returns all commissioned nodes. When a session daemon is running it
+// queries the daemon via its Unix socket; otherwise it opens the DB with the
+// default (blocking) timeout. Use this for normal command paths.
+func listNodes(fabricID uint64) ([]*store.Node, error) {
+	dc := daemon.NewClient("")
+	if dc.IsRunning() {
+		return dc.ListNodes(fabricID)
+	}
+	s, err := openStore()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+	return s.ListNodes(fabricID)
+}
+
 // listNodesForCompletion returns all commissioned nodes for use in shell
 // completion and target-resolution code paths. When a session daemon is
 // running it queries the daemon via its Unix socket (avoiding the BoltDB

--- a/cli/fabric.go
+++ b/cli/fabric.go
@@ -6,7 +6,6 @@ package cli
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/p0fi/matter-cli/cli/completion"
@@ -135,7 +134,7 @@ func newFabricResetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fid := fabricID()
 
-			nodes, err := listNodesForCompletion(fid)
+			nodes, err := listNodes(fid)
 			if err != nil {
 				return fmt.Errorf("listing nodes: %w", err)
 			}
@@ -160,8 +159,11 @@ func newFabricResetCmd() *cobra.Command {
 			yes, _ := cmd.Flags().GetBool("yes")
 			if !yes {
 				fmt.Fprintf(w, "? Remove all %d devices from the fabric? [y/N] ", len(nodes))
-				scanner := bufio.NewScanner(os.Stdin)
+				scanner := bufio.NewScanner(cmd.InOrStdin())
 				if !scanner.Scan() {
+					if err := scanner.Err(); err != nil {
+						return fmt.Errorf("reading confirmation: %w", err)
+					}
 					return nil
 				}
 				answer := strings.TrimSpace(strings.ToLower(scanner.Text()))

--- a/cli/fabric.go
+++ b/cli/fabric.go
@@ -4,7 +4,10 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/p0fi/matter-cli/cli/completion"
 	"github.com/p0fi/matter-cli/cli/output"
@@ -35,6 +38,7 @@ func newFabricCmd() *cobra.Command {
 	cmd.AddCommand(newFabricLsCmd())
 	cmd.AddCommand(newFabricInfoCmd())
 	cmd.AddCommand(newFabricRemoveCmd())
+	cmd.AddCommand(newFabricResetCmd())
 	return cmd
 }
 
@@ -116,6 +120,69 @@ func newFabricInfoCmd() *cobra.Command {
 			return f.Format(cmd.OutOrStdout(), fabric)
 		},
 	}
+}
+
+// newFabricResetCmd creates `matter fabric reset` which removes all
+// commissioned devices from the local fabric store. The fabric identity
+// (root certificate and keys) is preserved so new devices can still be
+// commissioned afterwards. No network commands are sent to the devices.
+func newFabricResetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Remove all commissioned devices from the fabric",
+		Example: `  matter fabric reset
+  matter fabric reset --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fid := fabricID()
+
+			nodes, err := listNodesForCompletion(fid)
+			if err != nil {
+				return fmt.Errorf("listing nodes: %w", err)
+			}
+			if len(nodes) == 0 {
+				fmt.Fprintln(cmd.ErrOrStderr(), output.Muted("No commissioned devices found."))
+				return nil
+			}
+
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "%s This will permanently remove %d device(s) from the fabric:\n\n",
+				output.WarningIcon(), len(nodes))
+			for _, n := range nodes {
+				if n.Name != "" {
+					fmt.Fprintf(w, "  • %s %s\n",
+						n.Name, output.Muted(fmt.Sprintf("(node %d)", n.ID)))
+				} else {
+					fmt.Fprintf(w, "  • node %d\n", n.ID)
+				}
+			}
+			fmt.Fprintln(w)
+
+			yes, _ := cmd.Flags().GetBool("yes")
+			if !yes {
+				fmt.Fprintf(w, "? Remove all %d devices from the fabric? [y/N] ", len(nodes))
+				scanner := bufio.NewScanner(os.Stdin)
+				if !scanner.Scan() {
+					return nil
+				}
+				answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+				if answer != "y" && answer != "yes" {
+					return nil
+				}
+			}
+
+			for _, n := range nodes {
+				if err := deleteNode(fid, n.ID); err != nil {
+					return fmt.Errorf("removing node %d: %w", n.ID, err)
+				}
+			}
+
+			fmt.Fprintf(w, "%s Removed %d device(s) from fabric.\n",
+				output.SuccessIcon(), len(nodes))
+			return nil
+		},
+	}
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+	return cmd
 }
 
 // newFabricRemoveCmd creates `matter fabric remove` which removes a


### PR DESCRIPTION
## Summary

- Adds `matter fabric reset [--yes|-y]` command that removes all commissioned devices from the local store in one step
- Lists devices and prompts for confirmation before proceeding (`--yes` skips the prompt)
- Preserves the fabric identity (root certificate and keys) — only nodes are removed
- Daemon-aware: routes deletions through the daemon socket when it holds the BoltDB lock

Closes #30

## Test plan

- [x] Run `matter fabric ls` to verify devices exist, then `matter fabric reset` and confirm the prompt works
- [x] Run `matter fabric reset --yes` to verify the skip-confirmation flag
- [x] Run `matter fabric reset` on an empty fabric to verify the "No commissioned devices found." message
- [ ] Run with session daemon active to verify daemon-aware deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)