### PR TITLE
fix: Use streaming mDNS browse for commissioning discovery

### DIFF
--- a/internal/controller/adapters.go
+++ b/internal/controller/adapters.go
@@ -8,6 +8,8 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"log/slog"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/p0fi/matter-cli/internal/commissioning"
@@ -55,7 +57,7 @@ func (d *controllerDiscoverer) DiscoverCommissionable(ctx context.Context, discr
 				return false
 			}
 		}
-		addr = fmt.Sprintf("%s:%d", dev.IPs[0], dev.Port)
+		addr = net.JoinHostPort(dev.IPs[0].String(), strconv.Itoa(dev.Port))
 		return true
 	})
 	if err != nil {

--- a/internal/controller/adapters.go
+++ b/internal/controller/adapters.go
@@ -34,11 +34,6 @@ type controllerDiscoverer struct {
 }
 
 func (d *controllerDiscoverer) DiscoverCommissionable(ctx context.Context, discriminator uint16, _ commissioning.DiscoveryCapabilities) (string, error) {
-	devices, err := d.browser.DiscoverCommissionable(ctx, 15*time.Second)
-	if err != nil {
-		return "", fmt.Errorf("mDNS discovery: %w", err)
-	}
-
 	// Manual pairing codes only encode the upper 4 bits of the 12-bit
 	// discriminator (the "short discriminator"). ParseManualPairingCode
 	// stores it as shortDisc<<8, leaving the lower 8 bits zero. When we
@@ -46,21 +41,30 @@ func (d *controllerDiscoverer) DiscoverCommissionable(ctx context.Context, discr
 	shortMatch := discriminator&0xFF == 0
 	shortDisc := discriminator >> 8
 
-	for _, dev := range devices {
+	var addr string
+	err := d.browser.WatchCommissionable(ctx, 15*time.Second, func(dev *discovery.Device) bool {
 		if len(dev.IPs) == 0 {
-			continue
+			return false
 		}
 		if shortMatch {
-			if dev.Discriminator>>8 == shortDisc {
-				return fmt.Sprintf("%s:%d", dev.IPs[0], dev.Port), nil
+			if dev.Discriminator>>8 != shortDisc {
+				return false
 			}
 		} else {
-			if dev.Discriminator == discriminator {
-				return fmt.Sprintf("%s:%d", dev.IPs[0], dev.Port), nil
+			if dev.Discriminator != discriminator {
+				return false
 			}
 		}
+		addr = fmt.Sprintf("%s:%d", dev.IPs[0], dev.Port)
+		return true
+	})
+	if err != nil {
+		return "", fmt.Errorf("mDNS discovery: %w", err)
 	}
-	return "", fmt.Errorf("no commissionable device found with discriminator %d", discriminator)
+	if addr == "" {
+		return "", fmt.Errorf("no commissionable device found with discriminator %d", discriminator)
+	}
+	return addr, nil
 }
 
 // StaticDiscoverer bypasses mDNS and returns a fixed address.

--- a/internal/discovery/mdns.go
+++ b/internal/discovery/mdns.go
@@ -25,8 +25,8 @@ type Browser interface {
 
 	// WatchCommissionable performs a streaming mDNS browse for commissionable
 	// devices (_matterc._udp), calling onDevice for every entry as it arrives.
-	// If onDevice returns true the browse is cancelled and nil is returned
-	// immediately — avoiding the full timeout wait.
+	// If onDevice returns true the browse is cancelled and nil is returned once
+	// the browse goroutine exits — avoiding the full timeout wait.
 	WatchCommissionable(ctx context.Context, timeout time.Duration, onDevice func(*Device) (done bool)) error
 }
 
@@ -56,9 +56,9 @@ func (b *MDNSBrowser) DiscoverCommissionable(ctx context.Context, timeout time.D
 // calling onDevice for every entry as it arrives.
 //
 // If onDevice returns true ("found what I needed"), WatchCommissionable cancels
-// the browse and returns nil immediately. If the timeout expires without
-// onDevice returning true, WatchCommissionable returns nil. A non-nil error is
-// only returned for transport-level failures.
+// the browse and returns nil once the browse goroutine has exited. If the
+// timeout expires without onDevice returning true, WatchCommissionable returns
+// nil. A non-nil error is only returned for transport-level failures.
 func (b *MDNSBrowser) WatchCommissionable(ctx context.Context, timeout time.Duration, onDevice func(*Device) (done bool)) error {
 	return b.watch(ctx, timeout, ServiceCommissionable, onDevice)
 }

--- a/internal/discovery/mdns.go
+++ b/internal/discovery/mdns.go
@@ -22,6 +22,12 @@ type Browser interface {
 	// DiscoverOperational browses for devices advertising _matter._tcp
 	// and returns all devices found within the given timeout.
 	DiscoverOperational(ctx context.Context, timeout time.Duration) ([]*Device, error)
+
+	// WatchCommissionable performs a streaming mDNS browse for commissionable
+	// devices (_matterc._udp), calling onDevice for every entry as it arrives.
+	// If onDevice returns true the browse is cancelled and nil is returned
+	// immediately — avoiding the full timeout wait.
+	WatchCommissionable(ctx context.Context, timeout time.Duration, onDevice func(*Device) (done bool)) error
 }
 
 // resolver abstracts the mDNS resolver for testability.
@@ -45,6 +51,18 @@ func (b *MDNSBrowser) DiscoverCommissionable(ctx context.Context, timeout time.D
 	return b.browse(ctx, timeout, ServiceCommissionable)
 }
 
+// WatchCommissionable performs a continuous streaming mDNS browse for
+// commissionable Matter devices (_matterc._udp) for up to the given timeout,
+// calling onDevice for every entry as it arrives.
+//
+// If onDevice returns true ("found what I needed"), WatchCommissionable cancels
+// the browse and returns nil immediately. If the timeout expires without
+// onDevice returning true, WatchCommissionable returns nil. A non-nil error is
+// only returned for transport-level failures.
+func (b *MDNSBrowser) WatchCommissionable(ctx context.Context, timeout time.Duration, onDevice func(*Device) (done bool)) error {
+	return b.watch(ctx, timeout, ServiceCommissionable, onDevice)
+}
+
 // DiscoverOperational browses for operational Matter devices advertising
 // the _matter._tcp service and returns all devices found within the given timeout.
 func (b *MDNSBrowser) DiscoverOperational(ctx context.Context, timeout time.Duration) ([]*Device, error) {
@@ -66,6 +84,11 @@ func (b *MDNSBrowser) DiscoverOperational(ctx context.Context, timeout time.Dura
 // empty result is not a failure; the caller should handle it). A non-nil
 // error is only returned for transport-level failures.
 func (b *MDNSBrowser) WatchOperational(ctx context.Context, timeout time.Duration, onDevice func(*Device) (done bool)) error {
+	return b.watch(ctx, timeout, ServiceOperational, onDevice)
+}
+
+// watch is the shared implementation for WatchCommissionable and WatchOperational.
+func (b *MDNSBrowser) watch(ctx context.Context, timeout time.Duration, svcType ServiceType, onDevice func(*Device) (done bool)) error {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -73,7 +96,7 @@ func (b *MDNSBrowser) WatchOperational(ctx context.Context, timeout time.Duratio
 
 	done := make(chan error, 1)
 	go func() {
-		done <- b.resolver.Browse(ctx, string(ServiceOperational), "local.", entries)
+		done <- b.resolver.Browse(ctx, string(svcType), "local.", entries)
 	}()
 
 	for {
@@ -82,11 +105,11 @@ func (b *MDNSBrowser) WatchOperational(ctx context.Context, timeout time.Duratio
 			if !ok {
 				// Channel closed — browse finished without finding the target.
 				if err := <-done; err != nil {
-					return fmt.Errorf("browsing %s: %w", ServiceOperational, err)
+					return fmt.Errorf("browsing %s: %w", svcType, err)
 				}
 				return nil
 			}
-			dev := entryToDevice(entry, ServiceOperational)
+			dev := entryToDevice(entry, svcType)
 			if onDevice(dev) {
 				// Caller found what it needed — cancel the browse and return.
 				cancel()
@@ -101,7 +124,7 @@ func (b *MDNSBrowser) WatchOperational(ctx context.Context, timeout time.Duratio
 			for range entries {
 			}
 			if err != nil {
-				return fmt.Errorf("browsing %s: %w", ServiceOperational, err)
+				return fmt.Errorf("browsing %s: %w", svcType, err)
 			}
 			return nil
 		}

--- a/internal/discovery/mdns_test.go
+++ b/internal/discovery/mdns_test.go
@@ -202,6 +202,80 @@ func TestBrowserImplementsInterface(t *testing.T) {
 	var _ Browser = (*MDNSBrowser)(nil)
 }
 
+func TestWatchCommissionable_FoundEarly(t *testing.T) {
+	mock := &mockResolver{
+		entries: []*zeroconf.ServiceEntry{
+			{
+				ServiceRecord: zeroconf.ServiceRecord{Instance: "unrelated"},
+				HostName:      "unrelated.local.",
+				Port:          5540,
+				AddrIPv4:      []net.IP{net.ParseIP("10.0.0.1")},
+				Text:          []string{"D=100", "CM=1"},
+			},
+			{
+				ServiceRecord: zeroconf.ServiceRecord{Instance: "target"},
+				HostName:      "target.local.",
+				Port:          5540,
+				AddrIPv4:      []net.IP{net.ParseIP("10.0.0.5")},
+				Text:          []string{"D=3840", "CM=1"},
+			},
+			{
+				ServiceRecord: zeroconf.ServiceRecord{Instance: "extra"},
+				HostName:      "extra.local.",
+				Port:          5540,
+				AddrIPv4:      []net.IP{net.ParseIP("10.0.0.99")},
+				Text:          []string{"D=200", "CM=1"},
+			},
+		},
+	}
+
+	browser := newMDNSBrowserWithResolver(mock)
+
+	var found *Device
+	var callCount int
+	err := browser.WatchCommissionable(context.Background(), 5*time.Second, func(dev *Device) bool {
+		callCount++
+		if dev.Discriminator == 3840 {
+			found = dev
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		t.Fatalf("WatchCommissionable: %v", err)
+	}
+	if found == nil {
+		t.Fatal("expected target device to be found, got nil")
+	}
+	if found.Name != "target" {
+		t.Errorf("Name = %q, want %q", found.Name, "target")
+	}
+	if found.ServiceType != ServiceCommissionable {
+		t.Errorf("ServiceType = %q, want %q", found.ServiceType, ServiceCommissionable)
+	}
+	if callCount > 2 {
+		t.Errorf("callback called %d times, expected at most 2 (stop on match)", callCount)
+	}
+}
+
+func TestWatchCommissionable_NotFound(t *testing.T) {
+	mock := &mockResolver{entries: nil}
+
+	browser := newMDNSBrowserWithResolver(mock)
+
+	var callCount int
+	err := browser.WatchCommissionable(context.Background(), 5*time.Second, func(_ *Device) bool {
+		callCount++
+		return false
+	})
+	if err != nil {
+		t.Fatalf("WatchCommissionable: unexpected error: %v", err)
+	}
+	if callCount != 0 {
+		t.Errorf("callback called %d times, want 0", callCount)
+	}
+}
+
 func TestWatchOperational_FoundEarly(t *testing.T) {
 	// Three entries are queued; the callback stops on the second match.
 	mock := &mockResolver{


### PR DESCRIPTION
## Summary

- On-network commissioning always took exactly 15s because `controllerDiscoverer` used the batch `DiscoverCommissionable` API which waits for the full timeout before returning results
- Added `WatchCommissionable` streaming method (mirroring the existing `WatchOperational`) that cancels the mDNS browse as soon as the matching discriminator is found
- Refactored `WatchOperational` and `WatchCommissionable` to share a private `watch()` method to avoid duplication

## Test plan

- [x] `mise run lint` passes
- [x] `mise run test` passes (all packages)
- [x] New unit tests: `TestWatchCommissionable_FoundEarly`, `TestWatchCommissionable_NotFound`
- [x] Manual: commission an on-network device and verify discovery completes in ~1-2s instead of 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)