### PR TITLE
fix: resolve missing Write method on Linux BLE characteristic

### DIFF
--- a/internal/transport/ble_adapter_tinygo.go
+++ b/internal/transport/ble_adapter_tinygo.go
@@ -319,7 +319,7 @@ func (tc *tinygoCharacteristic) WriteWithResponse(data []byte) (int, error) {
 		}
 		slog.Debug("ble: C1 WriteWithResponse via bt_queue failed, falling back to tinygo Write")
 	}
-	return tc.c.Write(data)
+	return btCharWriteWithResponse(tc.c, data)
 }
 
 // EnableNotifications registers cb to be called on each indication or

--- a/internal/transport/ble_adapter_tinygo.go
+++ b/internal/transport/ble_adapter_tinygo.go
@@ -302,8 +302,9 @@ func (tc *tinygoCharacteristic) Write(data []byte) (int, error) {
 // Request when Write Without Response consistently fails to elicit a reply.
 //
 // On macOS the write is dispatched to bt_queue via the fresh pointer, just
-// like Write(). On other platforms this falls back to tinygo's
-// Write() method (not WriteWithoutResponse).
+// like Write(). On other platforms this falls back to btCharWriteWithResponse,
+// which calls DeviceCharacteristic.Write() on Darwin and
+// WriteWithoutResponse() as a best-effort fallback on all other platforms.
 //
 // NOTE: This only succeeds if the characteristic also advertises the Write
 // (with response) GATT property. If not, CoreBluetooth delivers a
@@ -317,7 +318,7 @@ func (tc *tinygoCharacteristic) WriteWithResponse(data []byte) (int, error) {
 			slog.Debug("ble: C1 WriteWithResponse dispatched to bt_queue", "bytes", n)
 			return n, nil
 		}
-		slog.Debug("ble: C1 WriteWithResponse via bt_queue failed, falling back to tinygo Write")
+		slog.Debug("ble: C1 WriteWithResponse via bt_queue failed, falling back to btCharWriteWithResponse")
 	}
 	return btCharWriteWithResponse(tc.c, data)
 }

--- a/internal/transport/ble_write_darwin.go
+++ b/internal/transport/ble_write_darwin.go
@@ -1,0 +1,15 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !noble && darwin
+
+package transport
+
+import ble "tinygo.org/x/bluetooth"
+
+// btCharWriteWithResponse performs a GATT Write Request (with ATT-level
+// response) on a characteristic. On Darwin, tinygo exposes Write() for
+// this purpose.
+func btCharWriteWithResponse(c ble.DeviceCharacteristic, data []byte) (int, error) {
+	return c.Write(data)
+}

--- a/internal/transport/ble_write_other.go
+++ b/internal/transport/ble_write_other.go
@@ -1,0 +1,17 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !noble && !darwin
+
+package transport
+
+import ble "tinygo.org/x/bluetooth"
+
+// btCharWriteWithResponse performs the best available write-with-response on
+// a characteristic. On Linux and Windows, tinygo's bluetooth only exposes
+// WriteWithoutResponse — there is no GATT Write Request available through the
+// BlueZ D-Bus API in this library version. We use WriteWithoutResponse as a
+// best-effort fallback.
+func btCharWriteWithResponse(c ble.DeviceCharacteristic, data []byte) (int, error) {
+	return c.WriteWithoutResponse(data)
+}

--- a/internal/transport/ble_write_other.go
+++ b/internal/transport/ble_write_other.go
@@ -8,10 +8,10 @@ package transport
 import ble "tinygo.org/x/bluetooth"
 
 // btCharWriteWithResponse performs the best available write-with-response on
-// a characteristic. On Linux and Windows, tinygo's bluetooth only exposes
-// WriteWithoutResponse — there is no GATT Write Request available through the
-// BlueZ D-Bus API in this library version. We use WriteWithoutResponse as a
-// best-effort fallback.
+// a characteristic. On non-Darwin builds in this configuration, tinygo's
+// bluetooth API only exposes WriteWithoutResponse, so there is no available
+// GATT write-with-response operation through this library version. We use
+// WriteWithoutResponse as a best-effort fallback.
 func btCharWriteWithResponse(c ble.DeviceCharacteristic, data []byte) (int, error) {
 	return c.WriteWithoutResponse(data)
 }


### PR DESCRIPTION
## Summary

- On Linux, `tinygo.org/x/bluetooth`'s `DeviceCharacteristic` only exposes `WriteWithoutResponse` — there is no `Write` (GATT Write Request) method
- The `WriteWithResponse` fallback path in `tinygoCharacteristic` called `tc.c.Write()` directly, which compiled fine on Darwin (where CoreBluetooth exposes both) but broke the Linux build
- Introduced `ble_write_darwin.go` and `ble_write_other.go` with a `btCharWriteWithResponse` helper that calls the right method per platform

## Test plan

- [x] `mise run build` passes on macOS (Darwin)
- [x] `GOOS=linux GOARCH=amd64 go build ./...` cross-compiles cleanly
- [x] `mise run lint` passes
- [x] `mise run test` passes (all packages green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)