### PR TITLE
fix: hide cluster shorthand commands from root help (#39)

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -1189,8 +1189,9 @@ func registerShorthandClusters() {
 	for _, cl := range clusters.Global.AllClusters() {
 		clCopy := cl
 		cmd := &cobra.Command{
-			Use:   clCopy.Name,
-			Short: fmt.Sprintf("Shorthand commands for %s cluster", clCopy.DisplayName),
+			Use:         clCopy.Name,
+			Short:       fmt.Sprintf("Shorthand commands for %s cluster", clCopy.DisplayName),
+			Annotations: map[string]string{"shorthand-cluster": "true"},
 		}
 
 		// Add a subcommand for each command in the cluster.

--- a/cli/completion_test.go
+++ b/cli/completion_test.go
@@ -671,6 +671,38 @@ func TestFilterShorthandCommands_NodeOnly(t *testing.T) {
 	}
 }
 
+// TestRootHelp_ShorthandClusterFiltering verifies that the styled root help
+// template: (1) hides shorthand cluster commands, (2) shows the cluster
+// command, and (3) includes discoverability hint lines.
+func TestRootHelp_ShorthandClusterFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	rootCmd.SetArgs([]string{"--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	help := buf.String()
+
+	// The cluster command should appear in help.
+	assert.Contains(t, help, "cluster", "cluster command should appear in root help")
+
+	// At least one known shorthand cluster command should be absent.
+	require.NotEmpty(t, shorthandCmds, "at least one shorthand cluster command must be registered")
+	assert.NotContains(t, help, shorthandCmds[0].Name(),
+		"shorthand cluster commands should be hidden from root help")
+
+	// Discoverability hint lines should be visible.
+	assert.Contains(t, help, "matter cluster list",
+		"cluster list hint should appear in root help")
+	assert.Contains(t, help, "matter <ClusterName> --help",
+		"shorthand hint should appear in root help")
+}
+
 // TestFilterShorthandCommands_ExplicitEndpoint verifies that when an
 // endpoint-explicit target is set (ExplicitEndpoint=true), the device command
 // is hidden and cluster commands are not globally hidden.

--- a/cli/root.go
+++ b/cli/root.go
@@ -262,7 +262,7 @@ func styleCmdPad(padding int, name string) string {
 // Template funcs styleHeader, styleBold, styleDim, styleCmd, and styleFlags
 // are registered in init() via cobra.AddTemplateFuncs.
 func styledUsageTemplate() string {
-	return `{{ "USAGE" | styleHeader }}
+	return fmt.Sprintf(`{{ "USAGE" | styleHeader }}
   {{ .UseLine | styleBold }}{{if .HasAvailableSubCommands}} [command]{{end}}
 {{- if gt (len .Aliases) 0}}
 
@@ -280,10 +280,10 @@ func styledUsageTemplate() string {
 
 {{$group.Title | trimTrailingWhitespaces | styleHeader}}
 {{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")) (not (isShorthandCluster .)))}}  {{.Name | styleCmdPad $pad}} {{.Short}}
-{{end}}{{end}}{{if eq $group.ID "clusters"}}
+{{end}}{{end}}{{if eq $group.ID "%s"}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (eq .Name "cluster") .IsAvailableCommand (not (isShorthandCluster .)))}}
   {{ "Run " | styleDim }}{{ "matter cluster list" | styleBold }}{{ " for all available clusters." | styleDim }}
   {{ "Use " | styleDim }}{{ "matter <ClusterName> --help" | styleBold }}{{ " for shorthand commands (e.g. " | styleDim }}{{ "matter OnOff --help" | styleBold }}{{ ")." | styleDim }}
-{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}
 {{- if not .AllChildCommandsHaveGroup}}
 
 {{ "ADDITIONAL COMMANDS" | styleHeader }}
@@ -301,5 +301,5 @@ func styledUsageTemplate() string {
 {{- end}}
 
   {{ "Use " | styleDim }}{{ "matter [command] --help" | styleBold }}{{ " for more information about a command." | styleDim }}
-`
+`, groupClusters)
 }

--- a/cli/root.go
+++ b/cli/root.go
@@ -41,6 +41,10 @@ var rootCmd = &cobra.Command{
 	Use:   "matter",
 	Short: "A pure Go Matter controller CLI",
 	Long:  "matter is a command-line tool for interacting with Matter smart home devices.",
+	Example: "  $ matter commission code MT:Y3.13OTB00KA0648G00\n" +
+		"  $ matter @kitchen/1 OnOff Toggle\n" +
+		"  $ matter @1/1 OnOff read OnOff\n" +
+		"  $ matter @1/1 LevelControl write CurrentLevel 128",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := setupLogging(cmd); err != nil {
 			return err
@@ -62,12 +66,15 @@ func init() {
 
 	// Register template functions for styled help output.
 	cobra.AddTemplateFuncs(template.FuncMap{
-		"styleHeader":  output.Header,
-		"styleBold":    output.Bold,
-		"styleDim":     output.Dim,
-		"styleCmd":     output.Command,
-		"styleCmdPad":  styleCmdPad,
-		"styleFlags":   styleFlagUsages,
+		"styleHeader":         output.Header,
+		"styleBold":           output.Bold,
+		"styleDim":            output.Dim,
+		"styleCmd":            output.Command,
+		"styleCmdPad":         styleCmdPad,
+		"styleFlags":          styleFlagUsages,
+		"isShorthandCluster":  isShorthandCluster,
+		"visibleCmdPadding":   visibleCmdPadding,
+		"splitLines":          func(s string) []string { return strings.Split(s, "\n") },
 	})
 
 	// Register command groups.
@@ -220,6 +227,27 @@ func styleFlagUsages(s string) string {
 	})
 }
 
+// isShorthandCluster reports whether cmd is a generated shorthand cluster
+// command. These are hidden from the root help output but remain active for
+// direct invocation and shell completion.
+func isShorthandCluster(cmd *cobra.Command) bool {
+	return cmd.Annotations["shorthand-cluster"] == "true"
+}
+
+// visibleCmdPadding returns the column width needed to align descriptions for
+// the visible (non-shorthand-cluster) commands in cmds. It replaces cobra's
+// built-in .NamePadding, which counts all registered commands including hidden
+// shorthand cluster names that dominate the width.
+func visibleCmdPadding(cmds []*cobra.Command) int {
+	max := 0
+	for _, cmd := range cmds {
+		if !isShorthandCluster(cmd) && len(cmd.Name()) > max {
+			max = len(cmd.Name())
+		}
+	}
+	return max + 2
+}
+
 // styleCmdPad styles a command name in cyan and right-pads it to the given
 // width based on the plain-text length (ignoring ANSI escape sequences).
 func styleCmdPad(padding int, name string) string {
@@ -244,17 +272,22 @@ func styledUsageTemplate() string {
 {{- if .HasExample}}
 
 {{ "EXAMPLES" | styleHeader }}
-{{ .Example | styleDim }}
+{{- range (splitLines .Example)}}
+{{ . | styleDim }}
 {{- end}}
-{{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{range $group := .Groups}}
+{{- end}}
+{{- if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{$pad := visibleCmdPadding $cmds}}{{range $group := .Groups}}
 
 {{$group.Title | trimTrailingWhitespaces | styleHeader}}
-{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}  {{.Name | styleCmdPad .NamePadding}} {{.Short}}
-{{end}}{{end}}{{end}}
+{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")) (not (isShorthandCluster .)))}}  {{.Name | styleCmdPad $pad}} {{.Short}}
+{{end}}{{end}}{{if eq $group.ID "clusters"}}
+  {{ "Run " | styleDim }}{{ "matter cluster list" | styleBold }}{{ " for all available clusters." | styleDim }}
+  {{ "Use " | styleDim }}{{ "matter <ClusterName> --help" | styleBold }}{{ " for shorthand commands (e.g. " | styleDim }}{{ "matter OnOff --help" | styleBold }}{{ ")." | styleDim }}
+{{end}}{{end}}
 {{- if not .AllChildCommandsHaveGroup}}
 
 {{ "ADDITIONAL COMMANDS" | styleHeader }}
-{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}  {{.Name | styleCmdPad .NamePadding}} {{.Short}}
+{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}  {{.Name | styleCmdPad $pad}} {{.Short}}
 {{end}}{{end}}{{end}}{{end}}
 {{- if .HasAvailableLocalFlags}}
 
@@ -267,6 +300,6 @@ func styledUsageTemplate() string {
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces | styleFlags}}
 {{- end}}
 
-  {{ "Use \"" | styleDim }}{{ "matter [command] --help" | styleBold }}{{ "\" for more information about a command." | styleDim }}
+  {{ "Use " | styleDim }}{{ "matter [command] --help" | styleBold }}{{ " for more information about a command." | styleDim }}
 `
 }


### PR DESCRIPTION
## Summary

- Cluster shorthand commands (133 of them) are no longer listed individually in `matter help`; instead the CLUSTER COMMANDS section shows only the `cluster` command plus a discoverable hint
- Commands are identified by a new `"shorthand-cluster": "true"` annotation and filtered out via a custom `isShorthandCluster` template function — no `Hidden: true`, so tab-completion still offers all cluster names
- `matter help` now fits in 40 lines (down from 169); `matter OnOff --help` still works; `matter cluster list` is the actionable discovery path

## Test plan

- [x] `matter help` output line count: 40 (down from 169)
- [x] `matter OnOff --help` still shows subcommands
- [x] `matter __complete ""` still offers `OnOff`, `AccessControl`, etc. for tab-completion
- [x] `mise run lint` — clean
- [x] `mise run test` — all pass

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)