### PR TITLE
feat: rename payload command to code, add human-readable fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,17 @@ matter use --show
 matter use --clear
 ```
 
+### Code parsing & generation
+
+```bash
+# Parse a QR code or manual pairing code
+matter code parse "MT:Y3.13OTB00KA0648G00"
+matter code parse "34970112332"
+
+# Generate a QR code and manual pairing code from parameters
+matter code generate --vid 0xFFF1 --pid 0x8000 --passcode 12345678 --discriminator 3840
+```
+
 ### Cluster interaction
 
 ```bash

--- a/cli/code.go
+++ b/cli/code.go
@@ -5,6 +5,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/p0fi/matter-cli/cli/output"
 	"github.com/p0fi/matter-cli/internal/commissioning"
@@ -13,26 +14,66 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(withGroup(newPayloadCmd(), groupTools))
+	rootCmd.AddCommand(withGroup(newCodeCmd(), groupTools))
 }
 
-// newPayloadCmd creates the `matter payload` subcommand group.
-func newPayloadCmd() *cobra.Command {
+// newCodeCmd creates the `matter code` subcommand group.
+func newCodeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "payload",
-		Short: "Parse or generate Matter setup payloads (QR codes, manual pairing codes)",
+		Use:   "code",
+		Short: "Parse or generate Matter setup codes (QR codes, manual pairing codes)",
 	}
-	cmd.AddCommand(newPayloadParseCmd())
-	cmd.AddCommand(newPayloadGenerateCmd())
+	cmd.AddCommand(newCodeParseCmd())
+	cmd.AddCommand(newCodeGenerateCmd())
 	return cmd
 }
 
-func newPayloadParseCmd() *cobra.Command {
+// formatCommissioningFlow returns a human-readable string for a CommissioningFlow value.
+func formatCommissioningFlow(f commissioning.CommissioningFlow) string {
+	switch f {
+	case commissioning.FlowStandard:
+		return fmt.Sprintf("Standard (%d)", f)
+	case commissioning.FlowUserIntent:
+		return fmt.Sprintf("User-Intent (%d)", f)
+	case commissioning.FlowCustom:
+		return fmt.Sprintf("Custom (%d)", f)
+	default:
+		return fmt.Sprintf("Unknown (%d)", f)
+	}
+}
+
+// formatDiscoveryCapabilities returns a human-readable string listing all set
+// discovery capability flags together with the raw hex value.
+func formatDiscoveryCapabilities(d commissioning.DiscoveryCapabilities) string {
+	type flag struct {
+		bit  commissioning.DiscoveryCapabilities
+		name string
+	}
+	flags := []flag{
+		{commissioning.DiscoverySoftAP, "SoftAP"},
+		{commissioning.DiscoveryBLE, "BLE"},
+		{commissioning.DiscoveryOnNetwork, "OnNetwork"},
+	}
+
+	var names []string
+	for _, f := range flags {
+		if d&f.bit != 0 {
+			names = append(names, f.name)
+		}
+	}
+
+	if len(names) == 0 {
+		return fmt.Sprintf("None (0x%02X)", d)
+	}
+	return fmt.Sprintf("%s (0x%02X)", strings.Join(names, ", "), d)
+}
+
+func newCodeParseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "parse <code>",
 		Short: "Parse a QR code or manual pairing code",
-		Example: `  matter payload parse "MT:Y3.13OTB00KA0648G00"
-  matter payload parse "34970112332"`,
+		Example: `  matter code parse "MT:Y3.13OTB00KA0648G00"
+  matter code parse "34970112332"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			code := args[0]
@@ -44,6 +85,13 @@ func newPayloadParseCmd() *cobra.Command {
 				payload, err = commissioning.ParseQRCode(code)
 			} else {
 				payload, err = commissioning.ParseManualPairingCode(code)
+				if err != nil {
+					// Provide a hint if the code looks like it might be a QR code missing its prefix.
+					if looksLikeQRPayload(code) {
+						return fmt.Errorf("parsing setup code: %w\n\nHint: did you mean to include the \"MT:\" prefix? Try: matter code parse \"MT:%s\"", err, code)
+					}
+					return fmt.Errorf("parsing setup code: %w", err)
+				}
 			}
 			if err != nil {
 				return fmt.Errorf("parsing setup code: %w", err)
@@ -61,8 +109,8 @@ func newPayloadParseCmd() *cobra.Command {
 				fmt.Fprintf(w, "  %s       %s\n", output.Label("Version:"), output.Value(fmt.Sprintf("%d", payload.Version)))
 				fmt.Fprintf(w, "  %s     %s\n", output.Label("Vendor ID:"), output.Accent(vendordb.FormatVendorID(payload.VendorID)))
 				fmt.Fprintf(w, "  %s    %s\n", output.Label("Product ID:"), output.Accent(fmt.Sprintf("0x%04X", payload.ProductID)))
-				fmt.Fprintf(w, "  %s          %s\n", output.Label("Flow:"), output.Value(fmt.Sprintf("%d", payload.CommissioningFlow)))
-				fmt.Fprintf(w, "  %s     %s\n", output.Label("Discovery:"), output.Value(fmt.Sprintf("0x%02X", payload.DiscoveryCapabilities)))
+				fmt.Fprintf(w, "  %s          %s\n", output.Label("Flow:"), output.Value(formatCommissioningFlow(payload.CommissioningFlow)))
+				fmt.Fprintf(w, "  %s     %s\n", output.Label("Discovery:"), output.Value(formatDiscoveryCapabilities(payload.DiscoveryCapabilities)))
 				fmt.Fprintf(w, "  %s %s %s\n", output.Label("Discriminator:"), output.Bold(fmt.Sprintf("%d", payload.Discriminator)), output.Muted(fmt.Sprintf("(0x%03X)", payload.Discriminator)))
 				fmt.Fprintf(w, "  %s      %s\n", output.Label("Passcode:"), output.Bold(fmt.Sprintf("%d", payload.Passcode)))
 				fmt.Fprintln(w)
@@ -76,11 +124,26 @@ func newPayloadParseCmd() *cobra.Command {
 	}
 }
 
-func newPayloadGenerateCmd() *cobra.Command {
+// looksLikeQRPayload reports whether s looks like it could be a base38-encoded
+// QR payload that is missing the "MT:" prefix (all uppercase alphanumeric plus
+// '-' and '.', and at least 8 characters long).
+func looksLikeQRPayload(s string) bool {
+	if len(s) < 8 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || c == '-' || c == '.') {
+			return false
+		}
+	}
+	return true
+}
+
+func newCodeGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a QR code and manual pairing code from parameters",
-		Example: `  matter payload generate --vid 0xFFF1 --pid 0x8000 --passcode 12345678 --discriminator 3840`,
+		Example: `  matter code generate --vid 0xFFF1 --pid 0x8000 --passcode 12345678 --discriminator 3840`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			vid, _ := cmd.Flags().GetUint16("vid")
 			pid, _ := cmd.Flags().GetUint16("pid")

--- a/cli/code.go
+++ b/cli/code.go
@@ -63,7 +63,10 @@ func formatDiscoveryCapabilities(d commissioning.DiscoveryCapabilities) string {
 	}
 
 	if len(names) == 0 {
-		return fmt.Sprintf("None (0x%02X)", d)
+		if d == 0 {
+			return fmt.Sprintf("None (0x%02X)", d)
+		}
+		return fmt.Sprintf("Unknown (0x%02X)", d)
 	}
 	return fmt.Sprintf("%s (0x%02X)", strings.Join(names, ", "), d)
 }

--- a/cli/code_test.go
+++ b/cli/code_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/p0fi/matter-cli/internal/commissioning"
+)
+
+func TestFormatCommissioningFlow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input commissioning.CommissioningFlow
+		want  string
+	}{
+		{"standard", commissioning.FlowStandard, "Standard (0)"},
+		{"user-intent", commissioning.FlowUserIntent, "User-Intent (1)"},
+		{"custom", commissioning.FlowCustom, "Custom (2)"},
+		{"unknown", commissioning.CommissioningFlow(9), "Unknown (9)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatCommissioningFlow(tc.input)
+			if got != tc.want {
+				t.Errorf("formatCommissioningFlow(%d) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatDiscoveryCapabilities(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input commissioning.DiscoveryCapabilities
+		want  string
+	}{
+		{"none", 0, "None (0x00)"},
+		{"softap only", commissioning.DiscoverySoftAP, "SoftAP (0x01)"},
+		{"ble only", commissioning.DiscoveryBLE, "BLE (0x02)"},
+		{"on-network only", commissioning.DiscoveryOnNetwork, "OnNetwork (0x04)"},
+		{"ble and on-network", commissioning.DiscoveryBLE | commissioning.DiscoveryOnNetwork, "BLE, OnNetwork (0x06)"},
+		{"all flags", commissioning.DiscoverySoftAP | commissioning.DiscoveryBLE | commissioning.DiscoveryOnNetwork, "SoftAP, BLE, OnNetwork (0x07)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatDiscoveryCapabilities(tc.input)
+			if got != tc.want {
+				t.Errorf("formatDiscoveryCapabilities(0x%02X) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLooksLikeQRPayload(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid base38 string", "Y3.13OTB00KA0648G00", true},
+		{"all digits numeric", "34970112332", true},
+		{"too short", "ABC", false},
+		{"lowercase letters", "abcdefgh", false},
+		{"has MT prefix already", "MT:Y3.13OTB00KA0648G00", false}, // contains ':'
+		{"spaces", "ABCD EFG", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := looksLikeQRPayload(tc.input)
+			if got != tc.want {
+				t.Errorf("looksLikeQRPayload(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cli/code_test.go
+++ b/cli/code_test.go
@@ -45,6 +45,7 @@ func TestFormatDiscoveryCapabilities(t *testing.T) {
 		{"on-network only", commissioning.DiscoveryOnNetwork, "OnNetwork (0x04)"},
 		{"ble and on-network", commissioning.DiscoveryBLE | commissioning.DiscoveryOnNetwork, "BLE, OnNetwork (0x06)"},
 		{"all flags", commissioning.DiscoverySoftAP | commissioning.DiscoveryBLE | commissioning.DiscoveryOnNetwork, "SoftAP, BLE, OnNetwork (0x07)"},
+		{"unknown bits", commissioning.DiscoveryCapabilities(0x80), "Unknown (0x80)"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Renames `matter payload` → `matter code` (removes old `payload` command entirely)
- Flow field now shows human-readable name + numeric value: `Standard (0)`, `User-Intent (1)`, `Custom (2)`
- Discovery field lists flag names + hex value: `BLE, OnNetwork (0x06)`, `SoftAP, BLE, OnNetwork (0x07)`
- Helpful error hint when parsing fails and input looks like a bare base38 QR payload missing the `MT:` prefix
- Unit tests for `formatCommissioningFlow`, `formatDiscoveryCapabilities`, and `looksLikeQRPayload`
- CLAUDE.md updated with new `code` command examples

Closes #37

## Test plan

- [ ] `matter code parse "MT:Y3.13OTB00KA0648G00"` — Flow and Discovery show human-readable strings
- [ ] `matter code parse "34970112332"` — manual pairing code works
- [ ] `matter code parse "Y3.13OTB00KA0648G00"` (no prefix) — shows hint about `MT:` prefix
- [ ] `matter code generate --vid 0xFFF1 --pid 0x8000 --passcode 12345678 --discriminator 3840` — generates codes
- [ ] `matter payload` — command no longer exists
- [ ] `mise run test` passes
- [ ] `mise run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)