### PR TITLE
feat: bootstrap config file on first run, wire WiFi/Thread creds to config

### DIFF
--- a/cli/commission.go
+++ b/cli/commission.go
@@ -79,24 +79,25 @@ func stepDescription(step commissioning.CommissioningStep) string {
 	return step.String()
 }
 
+// getStringFlagOrViper returns the flag value when the flag was explicitly set,
+// otherwise falls back to the viper key (config file or env var).
+func getStringFlagOrViper(cmd *cobra.Command, flagName, viperKey string) string {
+	if cmd.Flags().Changed(flagName) {
+		v, _ := cmd.Flags().GetString(flagName)
+		return v
+	}
+	return viper.GetString(viperKey)
+}
+
 // buildNetworkCreds builds network credentials from CLI flags if provided,
 // falling back to config file values (wifi.ssid, wifi.password, thread.dataset)
 // and environment variables (MATTER_WIFI_SSID, MATTER_WIFI_PASSWORD,
 // MATTER_THREAD_DATASET) when flags are not explicitly set.
 // Returns the credentials and an error if validation fails.
 func buildNetworkCreds(cmd *cobra.Command) (*commissioning.NetworkCredentials, error) {
-	ssid, _ := cmd.Flags().GetString("wifi-ssid")
-	if ssid == "" {
-		ssid = viper.GetString("wifi.ssid")
-	}
-	password, _ := cmd.Flags().GetString("wifi-password")
-	if password == "" {
-		password = viper.GetString("wifi.password")
-	}
-	threadHex, _ := cmd.Flags().GetString("thread-dataset")
-	if threadHex == "" {
-		threadHex = viper.GetString("thread.dataset")
-	}
+	ssid := getStringFlagOrViper(cmd, "wifi-ssid", "wifi.ssid")
+	password := getStringFlagOrViper(cmd, "wifi-password", "wifi.password")
+	threadHex := getStringFlagOrViper(cmd, "thread-dataset", "thread.dataset")
 
 	if ssid != "" {
 		creds := commissioning.NewWiFiCredentials(ssid, password)

--- a/cli/commission.go
+++ b/cli/commission.go
@@ -79,12 +79,24 @@ func stepDescription(step commissioning.CommissioningStep) string {
 	return step.String()
 }
 
-// buildNetworkCreds builds network credentials from CLI flags if provided.
+// buildNetworkCreds builds network credentials from CLI flags if provided,
+// falling back to config file values (wifi.ssid, wifi.password, thread.dataset)
+// and environment variables (MATTER_WIFI_SSID, MATTER_WIFI_PASSWORD,
+// MATTER_THREAD_DATASET) when flags are not explicitly set.
 // Returns the credentials and an error if validation fails.
 func buildNetworkCreds(cmd *cobra.Command) (*commissioning.NetworkCredentials, error) {
 	ssid, _ := cmd.Flags().GetString("wifi-ssid")
+	if ssid == "" {
+		ssid = viper.GetString("wifi.ssid")
+	}
 	password, _ := cmd.Flags().GetString("wifi-password")
+	if password == "" {
+		password = viper.GetString("wifi.password")
+	}
 	threadHex, _ := cmd.Flags().GetString("thread-dataset")
+	if threadHex == "" {
+		threadHex = viper.GetString("thread.dataset")
+	}
 
 	if ssid != "" {
 		creds := commissioning.NewWiFiCredentials(ssid, password)

--- a/cli/commission_test.go
+++ b/cli/commission_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newTestCommissionCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("wifi-ssid", "", "")
+	cmd.Flags().String("wifi-password", "", "")
+	cmd.Flags().String("thread-dataset", "", "")
+	return cmd
+}
+
+func TestBuildNetworkCreds_FlagTakesPrecedenceOverViper(t *testing.T) {
+	viper.Reset()
+	viper.Set("wifi.ssid", "config-net")
+	viper.Set("wifi.password", "config-pass")
+	t.Cleanup(viper.Reset)
+
+	cmd := newTestCommissionCmd()
+	_ = cmd.Flags().Set("wifi-ssid", "flag-net")
+	_ = cmd.Flags().Set("wifi-password", "flag-pass")
+
+	creds, err := buildNetworkCreds(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected credentials, got nil")
+	}
+	if creds.WiFi == nil {
+		t.Fatal("expected WiFi credentials")
+	}
+	if creds.WiFi.SSID != "flag-net" {
+		t.Errorf("SSID = %q, want %q", creds.WiFi.SSID, "flag-net")
+	}
+	if creds.WiFi.Password != "flag-pass" {
+		t.Errorf("password = %q, want %q", creds.WiFi.Password, "flag-pass")
+	}
+}
+
+func TestBuildNetworkCreds_ViperUsedWhenFlagNotSet(t *testing.T) {
+	viper.Reset()
+	viper.Set("wifi.ssid", "config-net")
+	viper.Set("wifi.password", "config-pass")
+	t.Cleanup(viper.Reset)
+
+	cmd := newTestCommissionCmd()
+
+	creds, err := buildNetworkCreds(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected credentials, got nil")
+	}
+	if creds.WiFi == nil {
+		t.Fatal("expected WiFi credentials")
+	}
+	if creds.WiFi.SSID != "config-net" {
+		t.Errorf("SSID = %q, want %q", creds.WiFi.SSID, "config-net")
+	}
+}
+
+func TestBuildNetworkCreds_ExplicitEmptyFlagDoesNotFallback(t *testing.T) {
+	viper.Reset()
+	viper.Set("wifi.ssid", "config-net")
+	viper.Set("wifi.password", "config-pass")
+	t.Cleanup(viper.Reset)
+
+	cmd := newTestCommissionCmd()
+	// Explicitly set flag to empty string — must NOT fall back to viper.
+	_ = cmd.Flags().Set("wifi-ssid", "")
+
+	creds, err := buildNetworkCreds(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// ssid is "" (explicitly set) and password is "" (not set, viper has "config-pass")
+	// but ssid="" means no wifi creds are built — result should be nil.
+	if creds != nil && creds.WiFi != nil && creds.WiFi.SSID == "config-net" {
+		t.Error("explicit empty flag should not fall back to viper value")
+	}
+}
+
+func TestBuildNetworkCreds_ThreadDatasetFromViper(t *testing.T) {
+	viper.Reset()
+	// Minimal valid Thread Active Operational Dataset (53 bytes):
+	// Channel(0x00) + PAN ID(0x01) + Extended PAN ID(0x02) + Network Name(0x03) +
+	// Network Key(0x05) + Active Timestamp(0x0E) — all required TLV types present.
+	viper.Set("thread.dataset", "00030000150102face0208deadbeefcafe0001030474657374051000112233445566778899aabbccddeeff0e080000000000010000")
+	t.Cleanup(viper.Reset)
+
+	cmd := newTestCommissionCmd()
+
+	creds, err := buildNetworkCreds(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected credentials, got nil")
+	}
+	if creds.Thread == nil {
+		t.Fatal("expected Thread credentials")
+	}
+}
+
+func TestBuildNetworkCreds_NilWhenNoCredsSet(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cmd := newTestCommissionCmd()
+
+	creds, err := buildNetworkCreds(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds != nil {
+		t.Errorf("expected nil credentials, got %+v", creds)
+	}
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -139,17 +140,22 @@ func configDir() string {
 	return filepath.Join(home, ".config", "matter-cli")
 }
 
-// configTemplate is written to ~/.config/matter-cli/config.yaml on first run.
-// All keys are commented out so the file is self-documenting without changing
-// any defaults.
-const configTemplate = `# matter-cli configuration
-# ~/.config/matter-cli/config.yaml
+// configTemplateFor returns the config file template with the resolved path
+// embedded as a comment. All keys are commented out so the file is
+// self-documenting without changing any defaults.
+func configTemplateFor(cfgFile string) string {
+	return fmt.Sprintf(`# matter-cli configuration
+# %s
 
 # Default fabric ID used when --fabric-id is not specified.
 # default-fabric-id: 1
 
 # Output format: table | json | yaml (default: table for TTY, json for pipes).
 # format: table
+
+# Sticky default target set by "matter use @<node>/<endpoint>".
+# default-node: 0
+# default-endpoint: 0
 
 # WiFi credentials used during BLE commissioning.
 # Avoids passing --wifi-ssid and --wifi-password on every commission invocation.
@@ -160,7 +166,8 @@ const configTemplate = `# matter-cli configuration
 # Thread operational dataset (hex-encoded) used during BLE commissioning.
 # thread:
 #   dataset: 0e080000000000010000000300001235...
-`
+`, cfgFile)
+}
 
 func initConfig() {
 	dir := configDir()
@@ -168,18 +175,25 @@ func initConfig() {
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath(dir)
 	viper.SetEnvPrefix("MATTER")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 
 	// Bootstrap config file on first run so users can discover available keys.
 	cfgFile := filepath.Join(dir, "config.yaml")
-	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
-		if mkErr := os.MkdirAll(dir, 0o700); mkErr == nil {
-			_ = os.WriteFile(cfgFile, []byte(configTemplate), 0o600)
+	if mkErr := os.MkdirAll(dir, 0o700); mkErr == nil {
+		if f, err := os.OpenFile(cfgFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600); err == nil {
+			_, _ = f.WriteString(configTemplateFor(cfgFile))
+			_ = f.Close()
 		}
+		// os.O_EXCL ensures we never overwrite an existing config.
 	}
 
-	// Silently ignore missing or malformed config file — it is optional.
-	_ = viper.ReadInConfig()
+	if err := viper.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) {
+			fmt.Fprintf(os.Stderr, "warning: config file error: %v\n", err)
+		}
+	}
 }
 
 // maybeStartDaemon checks the --keep-alive / -K flag and, if set, ensures a

--- a/cli/root.go
+++ b/cli/root.go
@@ -139,6 +139,29 @@ func configDir() string {
 	return filepath.Join(home, ".config", "matter-cli")
 }
 
+// configTemplate is written to ~/.config/matter-cli/config.yaml on first run.
+// All keys are commented out so the file is self-documenting without changing
+// any defaults.
+const configTemplate = `# matter-cli configuration
+# ~/.config/matter-cli/config.yaml
+
+# Default fabric ID used when --fabric-id is not specified.
+# default-fabric-id: 1
+
+# Output format: table | json | yaml (default: table for TTY, json for pipes).
+# format: table
+
+# WiFi credentials used during BLE commissioning.
+# Avoids passing --wifi-ssid and --wifi-password on every commission invocation.
+# wifi:
+#   ssid: MyNetwork
+#   password: s3cr3t
+
+# Thread operational dataset (hex-encoded) used during BLE commissioning.
+# thread:
+#   dataset: 0e080000000000010000000300001235...
+`
+
 func initConfig() {
 	dir := configDir()
 	viper.SetConfigName("config")
@@ -147,7 +170,15 @@ func initConfig() {
 	viper.SetEnvPrefix("MATTER")
 	viper.AutomaticEnv()
 
-	// Silently ignore missing config file — it is optional.
+	// Bootstrap config file on first run so users can discover available keys.
+	cfgFile := filepath.Join(dir, "config.yaml")
+	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
+		if mkErr := os.MkdirAll(dir, 0o700); mkErr == nil {
+			_ = os.WriteFile(cfgFile, []byte(configTemplate), 0o600)
+		}
+	}
+
+	// Silently ignore missing or malformed config file — it is optional.
 	_ = viper.ReadInConfig()
 }
 

--- a/cli/root_test.go
+++ b/cli/root_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInitConfig_CreatesConfigOnFirstRun(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	initConfig()
+
+	cfgFile := filepath.Join(tmp, "matter-cli", "config.yaml")
+	data, err := os.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("config file is empty")
+	}
+	// Template should contain the actual resolved path.
+	if !containsStr(string(data), cfgFile) {
+		t.Errorf("config file does not contain its own path; content:\n%s", data)
+	}
+}
+
+func TestInitConfig_DoesNotOverwriteExistingConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, "matter-cli")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfgFile := filepath.Join(dir, "config.yaml")
+	original := "# my custom config\nformat: json\n"
+	if err := os.WriteFile(cfgFile, []byte(original), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	initConfig()
+	initConfig() // second call must also be a no-op
+
+	data, err := os.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != original {
+		t.Errorf("existing config was overwritten\ngot:  %q\nwant: %q", string(data), original)
+	}
+}


### PR DESCRIPTION
## Summary

- On first run, creates `~/.config/matter-cli/config.yaml` with all supported keys commented out — no more guessing key names
- `buildNetworkCreds` now falls back to viper for `wifi.ssid`, `wifi.password`, and `thread.dataset` when CLI flags are not explicitly set
- Env overrides work out of the box: `MATTER_WIFI_SSID`, `MATTER_WIFI_PASSWORD`, `MATTER_THREAD_DATASET`
- Explicit CLI flags still take priority over config/env

## Test plan

- [x] Delete or rename config file, run `matter fabric ls`, verify `~/.config/matter-cli/config.yaml` is created with all keys commented out
- [x] Set `wifi.ssid` / `wifi.password` in config, run `matter commission ble "MT:..."` without `--wifi-ssid` flag — verify creds are picked up
- [x] Set `MATTER_WIFI_SSID=GuestNet`, run commission — verify env var overrides config
- [x] Pass `--wifi-ssid OtherNet` explicitly — verify CLI flag overrides config/env

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)