### PR TITLE
feat: matter rename for local + on-device labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,11 @@ matter @1 tree -L 4             # full tree including attribute values
 matter fabric reset             # remove all devices (interactive prompt)
 matter fabric reset --yes       # skip confirmation (for scripts/CI)
 
+# Rename a commissioned device (updates local store AND NodeLabel on the device)
+matter rename @1 "Kitchen Light"
+matter rename @1 "Kitchen Light" --local   # don't touch the device (offline)
+matter rename @1 --reset                   # restore name from ProductName
+
 # Set a sticky default target (node/endpoint)
 matter use @1/1
 matter use --show

--- a/cli/device.go
+++ b/cli/device.go
@@ -125,6 +125,21 @@ func deleteNode(fabricID, nodeID uint64) error {
 	return s.DeleteNode(fabricID, nodeID)
 }
 
+// saveNode persists an updated node record, routing through the daemon when it
+// is running so the BoltDB exclusive lock is respected.
+func saveNode(fabricID uint64, node *store.Node) error {
+	dc := daemon.NewClient("")
+	if dc.IsRunning() {
+		return dc.SaveNode(fabricID, node)
+	}
+	s, err := openStore()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	return s.SaveNode(fabricID, node)
+}
+
 // resolveNodeLabel returns the node's name if it has one, otherwise "node X".
 // Used to build consistent Bold-ready labels throughout CLI output.
 func resolveNodeLabel(nodeID uint64) string {

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -54,7 +54,7 @@ name, also clearing NodeLabel on the device.`,
   matter @1 rename "Living Room"
   matter rename @1 --reset
   matter rename @1 "Porch Lamp" --local`,
-		Args:              cobra.MaximumNArgs(2),
+		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: completion.TargetCompletionFunc(),
 		RunE:              runRename,
 	}
@@ -164,7 +164,7 @@ func parseRenameArgs(args []string) (string, error) {
 		idx = 1
 	}
 	if idx < len(args) {
-		return args[idx], nil
+		return strings.Join(args[idx:], " "), nil
 	}
 	return "", nil
 }

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -1,0 +1,333 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/p0fi/matter-cli/cli/completion"
+	"github.com/p0fi/matter-cli/cli/output"
+	"github.com/p0fi/matter-cli/internal/clusters/basicinformation"
+	"github.com/p0fi/matter-cli/internal/daemon"
+	"github.com/p0fi/matter-cli/internal/interaction"
+	"github.com/p0fi/matter-cli/internal/tlv"
+	"github.com/spf13/cobra"
+)
+
+// nodeLabelMaxBytes is the maximum byte length of BasicInformation.NodeLabel
+// per the Matter spec (string max 32 bytes, UTF-8 encoded).
+const nodeLabelMaxBytes = 32
+
+func init() {
+	rootCmd.AddCommand(withGroup(newRenameCmd(), groupDevices))
+	// Rename operates on a node as a whole, not an endpoint — hide it from
+	// completion whenever the user has an endpoint-explicit target set.
+	deviceOnlyCommands["rename"] = true
+}
+
+// newRenameCmd creates the top-level `matter rename` command which sets a
+// friendly name for a commissioned device both locally (used for CLI listings
+// and completion) and on the device (BasicInformation.NodeLabel, so other
+// controllers see the same label).
+func newRenameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rename [@target] <name>",
+		Short: "Rename a commissioned device locally and on the device",
+		Long: `Set a friendly name for a commissioned device.
+
+The local store name is updated (used for CLI listings and completion) and
+NodeLabel is written to the device's BasicInformation cluster so other
+controllers see the same label.
+
+When the device is unreachable the local name is still updated and a warning
+is printed. Use --local to skip the device write up front.
+
+The --reset flag re-reads ProductName from the device and uses it as the new
+name, also clearing NodeLabel on the device.`,
+		Example: `  matter rename @1 "Kitchen Light"
+  matter @1 rename "Living Room"
+  matter rename @1 --reset
+  matter rename @1 "Porch Lamp" --local`,
+		Args:              cobra.MaximumNArgs(2),
+		ValidArgsFunction: completion.TargetCompletionFunc(),
+		RunE:              runRename,
+	}
+	cmd.Flags().Bool("reset", false, "reset name by re-reading ProductName from the device")
+	cmd.Flags().Bool("local", false, "only update the local store; skip the NodeLabel write")
+	return cmd
+}
+
+// runRename implements `matter rename`.
+func runRename(cmd *cobra.Command, args []string) error {
+	newName, err := parseRenameArgs(args)
+	if err != nil {
+		return err
+	}
+
+	nodeID, _, err := requireTarget(cmd)
+	if err != nil {
+		return err
+	}
+
+	reset, _ := cmd.Flags().GetBool("reset")
+	local, _ := cmd.Flags().GetBool("local")
+
+	if reset && newName != "" {
+		return errors.New("--reset cannot be combined with a positional name")
+	}
+	if !reset {
+		if err := validateNodeLabel(newName); err != nil {
+			return err
+		}
+	}
+
+	fid := fabricID()
+	node, err := getNodeForCompletion(fid, nodeID)
+	if err != nil {
+		return fmt.Errorf("looking up node %d: %w", nodeID, err)
+	}
+	oldName := node.Name
+
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	stepper := output.NewStepper(cmd.OutOrStdout(), verbose)
+
+	ctx := cmd.Context()
+
+	if reset {
+		stepper.Step("Reading ProductName from device")
+		productName, err := readProductName(ctx, nodeID)
+		if err != nil {
+			stepper.Fail(fmt.Sprintf("Reading ProductName failed: %v", err))
+			return fmt.Errorf("reading ProductName: %w", err)
+		}
+		if strings.TrimSpace(productName) == "" {
+			return errors.New("device returned empty ProductName — specify an explicit name instead")
+		}
+		newName = productName
+
+		if !local {
+			stepper.Step("Clearing NodeLabel on device")
+			if err := writeNodeLabel(ctx, nodeID, ""); err != nil {
+				stepper.Fail(fmt.Sprintf("Clearing NodeLabel failed: %v", err))
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"%s Device did not accept NodeLabel clear; local name is still being updated.\n",
+					output.WarningIcon())
+			}
+		}
+	} else if !local {
+		stepper.Step(fmt.Sprintf("Writing NodeLabel=%q to device", newName))
+		if err := writeNodeLabel(ctx, nodeID, newName); err != nil {
+			stepper.Fail(fmt.Sprintf("Writing NodeLabel failed: %v", err))
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"%s Device is unreachable; local name is still being updated. Re-run with %s when it's back online.\n",
+				output.WarningIcon(), output.Bold("matter rename"))
+		}
+	}
+
+	warnOnNameConflict(cmd, fid, nodeID, newName)
+
+	node.Name = newName
+	if err := saveNode(fid, node); err != nil {
+		return fmt.Errorf("saving node: %w", err)
+	}
+
+	stepper.Success(fmt.Sprintf("Renamed node %d: %s → %s",
+		nodeID,
+		output.Bold(displayOldName(oldName)),
+		output.Bold(newName)))
+	return nil
+}
+
+// parseRenameArgs accepts the positional forms:
+//
+//	rename @1 "Kitchen"   (len=2, first arg is target)
+//	@1 rename "Kitchen"   (len=1, target already resolved inline)
+//	rename @1             (len=1, target only — for --reset)
+//	@1 rename             (len=0, target only — for --reset)
+//
+// It returns the user-supplied name (empty when only a target was given). If
+// the first argument is a @target it is parsed and stored in resolvedTarget.
+func parseRenameArgs(args []string) (string, error) {
+	idx := 0
+	if len(args) > 0 && IsTargetArg(args[0]) {
+		t, err := ParseTarget(args[0])
+		if err != nil {
+			return "", fmt.Errorf("invalid target %q: %w", args[0], err)
+		}
+		resolvedTarget = t
+		idx = 1
+	}
+	if idx < len(args) {
+		return args[idx], nil
+	}
+	return "", nil
+}
+
+// validateNodeLabel enforces the Matter NodeLabel constraints plus basic
+// ergonomics (no empty/whitespace-only strings).
+func validateNodeLabel(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return errors.New(`name is required (use "matter rename @<id> --reset" to restore the original ProductName)`)
+	}
+	if name != trimmed {
+		return errors.New("name must not start or end with whitespace")
+	}
+	if len(name) > nodeLabelMaxBytes {
+		return fmt.Errorf("name exceeds the %d-byte NodeLabel limit (got %d bytes)", nodeLabelMaxBytes, len(name))
+	}
+	return nil
+}
+
+// warnOnNameConflict prints a warning (but does not block) when another node
+// in the same fabric already has the same name.
+func warnOnNameConflict(cmd *cobra.Command, fabricID, nodeID uint64, name string) {
+	nodes, err := listNodesForCompletion(fabricID)
+	if err != nil {
+		return
+	}
+	for _, n := range nodes {
+		if n.ID == nodeID {
+			continue
+		}
+		if strings.EqualFold(n.Name, name) {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"%s Name %q is also used by node %d — completion will prefer the lowest node ID.\n",
+				output.WarningIcon(), name, n.ID)
+			return
+		}
+	}
+}
+
+// displayOldName returns a human-friendly representation of a prior name for
+// rename confirmation output.
+func displayOldName(old string) string {
+	if old == "" {
+		return "(unnamed)"
+	}
+	return old
+}
+
+// writeNodeLabel writes BasicInformation.NodeLabel (endpoint 0) on the device,
+// preferring the session daemon when available so a cached CASE session is
+// reused.
+func writeNodeLabel(ctx context.Context, nodeID uint64, label string) error {
+	const ep0 = uint16(0)
+
+	w := tlv.NewWriter()
+	if err := w.PutUTF8String(tlv.AnonymousTag(), label); err != nil {
+		return fmt.Errorf("encoding NodeLabel: %w", err)
+	}
+	payload := w.Bytes()
+
+	if dc, ok := connectViaDaemon(nodeID); ok {
+		slog.Debug("rename: writing NodeLabel via daemon", "node", nodeID)
+		resp, err := dc.Write(daemon.AttrWriteReq{
+			Endpoint:    ep0,
+			ClusterID:   basicinformation.ID,
+			AttributeID: basicinformation.AttrNodeLabel,
+			Data:        daemon.EncodeFields(payload),
+		})
+		if err != nil {
+			return fmt.Errorf("writing NodeLabel: %w", err)
+		}
+		for _, st := range resp.Statuses {
+			if st.StatusCode != 0 {
+				return fmt.Errorf("NodeLabel write rejected: status 0x%02X", st.StatusCode)
+			}
+		}
+		return nil
+	}
+
+	client, session, cleanup, err := connectToNode(ctx, nodeID)
+	if err != nil {
+		return fmt.Errorf("connecting to node: %w", err)
+	}
+	defer cleanup()
+
+	statuses, err := client.Write(ctx, session, interaction.AttributeWrite{
+		Path: interaction.NewAttributePath(ep0, basicinformation.ID, basicinformation.AttrNodeLabel),
+		Data: payload,
+	})
+	if err != nil {
+		return fmt.Errorf("writing NodeLabel: %w", err)
+	}
+	for _, st := range statuses {
+		if st.Status.Status != 0 {
+			return fmt.Errorf("NodeLabel write rejected: status 0x%02X", st.Status.Status)
+		}
+	}
+	return nil
+}
+
+// readProductName reads BasicInformation.ProductName (endpoint 0) from the
+// device. Used by --reset to restore the factory label.
+func readProductName(ctx context.Context, nodeID uint64) (string, error) {
+	const ep0 = uint16(0)
+
+	if dc, ok := connectViaDaemon(nodeID); ok {
+		slog.Debug("rename: reading ProductName via daemon", "node", nodeID)
+		resp, err := dc.Read(daemon.AttrPathReq{
+			Endpoint:    ep0,
+			ClusterID:   basicinformation.ID,
+			AttributeID: basicinformation.AttrProductName,
+		})
+		if err != nil {
+			return "", err
+		}
+		for _, r := range resp.Reports {
+			if r.StatusCode != 0 {
+				return "", fmt.Errorf("status 0x%02X", r.StatusCode)
+			}
+			data, derr := daemon.DecodeFields(r.Data)
+			if derr != nil {
+				return "", fmt.Errorf("decoding ProductName: %w", derr)
+			}
+			return decodeTLVString(data)
+		}
+		return "", errors.New("no report data")
+	}
+
+	client, session, cleanup, err := connectToNode(ctx, nodeID)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	reports, err := client.Read(ctx, session,
+		interaction.NewAttributePath(ep0, basicinformation.ID, basicinformation.AttrProductName))
+	if err != nil {
+		return "", err
+	}
+	for _, r := range reports {
+		if r.Status != nil {
+			return "", fmt.Errorf("status 0x%02X", r.Status.Status.Status)
+		}
+		if r.Data != nil {
+			return decodeTLVString(r.Data.Data)
+		}
+	}
+	return "", errors.New("no report data")
+}
+
+// decodeTLVString extracts a single UTF-8 string from a raw TLV element.
+func decodeTLVString(raw []byte) (string, error) {
+	if len(raw) == 0 {
+		return "", errors.New("empty TLV")
+	}
+	r := tlv.NewReader(bytes.NewReader(raw))
+	if err := r.Next(); err != nil {
+		return "", err
+	}
+	v, ok := r.Value().(string)
+	if !ok {
+		return "", fmt.Errorf("expected UTF-8 string TLV (got %T)", r.Value())
+	}
+	return v, nil
+}

--- a/cli/rename_test.go
+++ b/cli/rename_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 matter-cli contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/p0fi/matter-cli/internal/tlv"
+)
+
+func TestParseRenameArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantName     string
+		wantTargetID uint64
+		wantErr      bool
+	}{
+		{name: "target and name", args: []string{"@1", "Kitchen"}, wantName: "Kitchen", wantTargetID: 1},
+		{name: "name only with inline target", args: []string{"Kitchen"}, wantName: "Kitchen"},
+		{name: "target only for reset", args: []string{"@42"}, wantTargetID: 42},
+		{name: "no args for reset with inline target", args: nil},
+		{name: "invalid target", args: []string{"@notanum", "x"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolvedTarget = nil
+			got, err := parseRenameArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantName {
+				t.Errorf("name = %q, want %q", got, tc.wantName)
+			}
+			if tc.wantTargetID != 0 {
+				if resolvedTarget == nil || resolvedTarget.NodeID != tc.wantTargetID {
+					t.Errorf("resolvedTarget = %+v, want NodeID=%d", resolvedTarget, tc.wantTargetID)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateNodeLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		label   string
+		wantErr string // substring the error should contain; empty means expect no error
+	}{
+		{name: "normal", label: "Kitchen Light"},
+		{name: "exactly 32 bytes", label: strings.Repeat("a", 32)},
+		{name: "empty", label: "", wantErr: "required"},
+		{name: "only whitespace", label: "   ", wantErr: "required"},
+		{name: "trailing space", label: "Kitchen ", wantErr: "whitespace"},
+		{name: "leading space", label: " Kitchen", wantErr: "whitespace"},
+		{name: "33 bytes", label: strings.Repeat("a", 33), wantErr: "32-byte"},
+		{name: "multibyte within limit", label: "日本語 lamp"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNodeLabel(tc.label)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDisplayOldName(t *testing.T) {
+	if got := displayOldName(""); got != "(unnamed)" {
+		t.Errorf(`displayOldName("") = %q, want "(unnamed)"`, got)
+	}
+	if got := displayOldName("Kitchen"); got != "Kitchen" {
+		t.Errorf(`displayOldName("Kitchen") = %q, want "Kitchen"`, got)
+	}
+}
+
+func TestDecodeTLVString(t *testing.T) {
+	t.Run("valid string", func(t *testing.T) {
+		w := tlv.NewWriter()
+		if err := w.PutUTF8String(tlv.AnonymousTag(), "Kitchen Light"); err != nil {
+			t.Fatal(err)
+		}
+		got, err := decodeTLVString(w.Bytes())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "Kitchen Light" {
+			t.Errorf("got %q, want %q", got, "Kitchen Light")
+		}
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		_, err := decodeTLVString(nil)
+		if err == nil {
+			t.Error("expected error for empty input")
+		}
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		w := tlv.NewWriter()
+		if err := w.PutUnsignedInt(tlv.AnonymousTag(), 42); err != nil {
+			t.Fatal(err)
+		}
+		_, err := decodeTLVString(w.Bytes())
+		if err == nil {
+			t.Error("expected error for non-string TLV")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `matter rename @N <name>` — updates the local store (powers CLI listings and completion) and writes `BasicInformation.NodeLabel` on the device so other controllers see the same label.
- `--local` skips the device write for offline devices; on a failed device write the local name is still updated with a warning.
- `--reset` re-reads `ProductName` from the device and uses it as the name, also clearing `NodeLabel` on the device.
- Validates the spec's 32-byte `NodeLabel` limit and rejects whitespace-only names; warns (without blocking) when another node in the fabric already uses the same label.
- Adds a `saveNode` helper alongside `deleteNode` so the rename path respects the session daemon's BoltDB lock when one is running.

## Test plan
- [x] `mise run test` — 18 new subtests cover `parseRenameArgs`, `validateNodeLabel` (empty/whitespace/length/multibyte), `displayOldName`, `decodeTLVString`. All packages pass.
- [x] `go vet` clean.
- [ ] Live verification against matter.js: `matter rename @1 "Kitchen Light"`, `matter rename @1 --reset`, offline flow.

Closes #48