### PR TITLE
refactor: rename daemon-aware store wrappers to distinct verbs

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -157,7 +157,7 @@ func filterShorthandCommands(t *Target) {
 		fabricID = 1
 	}
 
-	node, err := getNodeForCompletion(fabricID, t.NodeID)
+	node, err := loadNodeForCompletion(fabricID, t.NodeID)
 	if err != nil {
 		return
 	}

--- a/cli/commission_window.go
+++ b/cli/commission_window.go
@@ -416,7 +416,7 @@ func loadNodeVIDPID(ctx context.Context, nodeID uint64, stepper *output.Stepper)
 	}
 
 	var node *store.Node
-	if n, err := getNodeForCompletion(fabricID, nodeID); err == nil {
+	if n, err := loadNodeForCompletion(fabricID, nodeID); err == nil {
 		node = n
 	}
 	if node != nil && (node.VendorID != 0 || node.ProductID != 0) {

--- a/cli/completion/completer.go
+++ b/cli/completion/completer.go
@@ -25,11 +25,11 @@ import (
 // fallback; when the daemon is running we query it via its Unix socket instead.
 const completionTimeout = 100 * time.Millisecond
 
-// listNodes returns all commissioned nodes for use in completion functions.
+// loadNodes returns all commissioned nodes for use in completion functions.
 // When the session daemon is running it queries the daemon via its Unix socket
 // so that the BoltDB file lock held by the daemon is not contended. When no
 // daemon is running, it opens the database directly with a short timeout.
-func listNodes(fabricID uint64) ([]*store.Node, error) {
+func loadNodes(fabricID uint64) ([]*store.Node, error) {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.ListNodes(fabricID)
@@ -246,7 +246,7 @@ func NodeIDCompletionFunc() func(cmd *cobra.Command, args []string, toComplete s
 			fabricID = 1
 		}
 
-		nodes, err := listNodes(fabricID)
+		nodes, err := loadNodes(fabricID)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
@@ -343,7 +343,7 @@ func TargetCompletionFunc() func(cmd *cobra.Command, args []string, toComplete s
 			fabricID = 1
 		}
 
-		nodes, err := listNodes(fabricID)
+		nodes, err := loadNodes(fabricID)
 		if err != nil || len(nodes) == 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/cli/completion/completer_test.go
+++ b/cli/completion/completer_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // setupTestStore creates a temporary BoltDB store with the given nodes and
-// configures the environment so that listNodes() will find it. Returns a
+// configures the environment so that loadNodes() will find it. Returns a
 // cleanup function that must be called when done.
 func setupTestStore(t *testing.T, fabricID uint64, nodes []*store.Node) func() {
 	t.Helper()

--- a/cli/decommission.go
+++ b/cli/decommission.go
@@ -108,7 +108,7 @@ func runDecommission(cmd *cobra.Command, args []string) error {
 			output.Muted(fmt.Sprintf("(fabric index %d)", fabricIndex))))
 	}
 
-	if err := deleteNode(fid, nodeID); err != nil {
+	if err := removeNode(fid, nodeID); err != nil {
 		return fmt.Errorf("removing node %d from local store: %w", nodeID, err)
 	}
 
@@ -126,7 +126,7 @@ func runDecommission(cmd *cobra.Command, args []string) error {
 // nodeDisplayLabel returns "<name> (node N)" when a name exists, otherwise
 // just "node N". The result is pre-styled for direct use in stepper output.
 func nodeDisplayLabel(fabricID, nodeID uint64) string {
-	if node, err := getNodeForCompletion(fabricID, nodeID); err == nil && node.Name != "" {
+	if node, err := loadNodeForCompletion(fabricID, nodeID); err == nil && node.Name != "" {
 		return output.Bold(node.Name) + " " + output.Muted(fmt.Sprintf("(node %d)", nodeID))
 	}
 	return output.Bold(fmt.Sprintf("node %d", nodeID))

--- a/cli/device.go
+++ b/cli/device.go
@@ -44,10 +44,10 @@ func openStoreForCompletion() (store.Store, error) {
 	return s, nil
 }
 
-// listNodes returns all commissioned nodes. When a session daemon is running it
+// loadNodes returns all commissioned nodes. When a session daemon is running it
 // queries the daemon via its Unix socket; otherwise it opens the DB with the
 // default (blocking) timeout. Use this for normal command paths.
-func listNodes(fabricID uint64) ([]*store.Node, error) {
+func loadNodes(fabricID uint64) ([]*store.Node, error) {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.ListNodes(fabricID)
@@ -60,11 +60,11 @@ func listNodes(fabricID uint64) ([]*store.Node, error) {
 	return s.ListNodes(fabricID)
 }
 
-// listNodesForCompletion returns all commissioned nodes for use in shell
+// loadNodesForCompletion returns all commissioned nodes for use in shell
 // completion and target-resolution code paths. When a session daemon is
 // running it queries the daemon via its Unix socket (avoiding the BoltDB
 // exclusive lock that the daemon holds). Otherwise it opens the DB directly.
-func listNodesForCompletion(fabricID uint64) ([]*store.Node, error) {
+func loadNodesForCompletion(fabricID uint64) ([]*store.Node, error) {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.ListNodes(fabricID)
@@ -77,10 +77,10 @@ func listNodesForCompletion(fabricID uint64) ([]*store.Node, error) {
 	return s.ListNodes(fabricID)
 }
 
-// getNodeForCompletion is like listNodesForCompletion but returns a single
+// loadNodeForCompletion is like loadNodesForCompletion but returns a single
 // node by ID, searching the full node list returned by the daemon or store.
-func getNodeForCompletion(fabricID, nodeID uint64) (*store.Node, error) {
-	nodes, err := listNodesForCompletion(fabricID)
+func loadNodeForCompletion(fabricID, nodeID uint64) (*store.Node, error) {
+	nodes, err := loadNodesForCompletion(fabricID)
 	if err != nil {
 		return nil, err
 	}
@@ -92,10 +92,10 @@ func getNodeForCompletion(fabricID, nodeID uint64) (*store.Node, error) {
 	return nil, fmt.Errorf("node %d not found in fabric %d", nodeID, fabricID)
 }
 
-// getFabric returns the fabric record, querying the daemon if it is running
+// loadFabric returns the fabric record, querying the daemon if it is running
 // (to avoid contending on the BoltDB exclusive lock), otherwise opening the
 // store directly.
-func getFabric(fabricID uint64) (*store.Fabric, error) {
+func loadFabric(fabricID uint64) (*store.Fabric, error) {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.GetFabric(fabricID)
@@ -108,11 +108,10 @@ func getFabric(fabricID uint64) (*store.Fabric, error) {
 	return s.GetFabric(fabricID)
 }
 
-
-// deleteNode removes a node record from the store, routing through the daemon
+// removeNode removes a node record from the store, routing through the daemon
 // when it is running so that the BoltDB exclusive lock is respected. The daemon
 // also evicts any cached CASE session for the node.
-func deleteNode(fabricID, nodeID uint64) error {
+func removeNode(fabricID, nodeID uint64) error {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.DeleteNode(fabricID, nodeID)
@@ -125,9 +124,9 @@ func deleteNode(fabricID, nodeID uint64) error {
 	return s.DeleteNode(fabricID, nodeID)
 }
 
-// saveNode persists an updated node record, routing through the daemon when it
-// is running so the BoltDB exclusive lock is respected.
-func saveNode(fabricID uint64, node *store.Node) error {
+// persistNode persists an updated node record, routing through the daemon when
+// it is running so the BoltDB exclusive lock is respected.
+func persistNode(fabricID uint64, node *store.Node) error {
 	dc := daemon.NewClient("")
 	if dc.IsRunning() {
 		return dc.SaveNode(fabricID, node)
@@ -147,7 +146,7 @@ func resolveNodeLabel(nodeID uint64) string {
 	if fid == 0 {
 		fid = 1
 	}
-	if node, err := getNodeForCompletion(fid, nodeID); err == nil && node.Name != "" {
+	if node, err := loadNodeForCompletion(fid, nodeID); err == nil && node.Name != "" {
 		return node.Name
 	}
 	return fmt.Sprintf("node %d", nodeID)

--- a/cli/fabric.go
+++ b/cli/fabric.go
@@ -51,7 +51,7 @@ func newFabricLsCmd() *cobra.Command {
   matter fabric ls --format json
   matter fabric ls -f yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nodes, err := listNodesForCompletion(fabricID())
+			nodes, err := loadNodesForCompletion(fabricID())
 			if err != nil {
 				return fmt.Errorf("listing nodes: %w", err)
 			}
@@ -94,7 +94,7 @@ func newFabricInfoCmd() *cobra.Command {
   matter fabric info --format json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fid := fabricID()
-			fabric, err := getFabric(fid)
+			fabric, err := loadFabric(fid)
 			if err != nil {
 				return fmt.Errorf("getting fabric %d: %w", fid, err)
 			}
@@ -111,7 +111,7 @@ func newFabricInfoCmd() *cobra.Command {
 				fmt.Fprintf(w, "  %s      %s\n", output.Label("Index:"), output.Value(fmt.Sprintf("%d", fabric.FabricIndex)))
 				fmt.Fprintf(w, "  %s    %s\n", output.Label("Created:"), output.Muted(fabric.CreatedAt.Format("2006-01-02 15:04:05")))
 
-				if nodes, err := listNodesForCompletion(fid); err == nil {
+				if nodes, err := loadNodesForCompletion(fid); err == nil {
 					fmt.Fprintf(w, "  %s    %s\n", output.Label("Devices:"), output.Value(fmt.Sprintf("%d", len(nodes))))
 				}
 				return nil
@@ -134,7 +134,7 @@ func newFabricResetCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fid := fabricID()
 
-			nodes, err := listNodes(fid)
+			nodes, err := loadNodes(fid)
 			if err != nil {
 				return fmt.Errorf("listing nodes: %w", err)
 			}
@@ -173,7 +173,7 @@ func newFabricResetCmd() *cobra.Command {
 			}
 
 			for _, n := range nodes {
-				if err := deleteNode(fid, n.ID); err != nil {
+				if err := removeNode(fid, n.ID); err != nil {
 					return fmt.Errorf("removing node %d: %w", n.ID, err)
 				}
 			}
@@ -237,9 +237,9 @@ use "matter decommission" instead.`,
 			fid := fabricID()
 
 			// Look up the node name before deleting for a friendlier confirmation.
-			node, lookupErr := getNodeForCompletion(fid, nodeID)
+			node, lookupErr := loadNodeForCompletion(fid, nodeID)
 
-			if err := deleteNode(fid, nodeID); err != nil {
+			if err := removeNode(fid, nodeID); err != nil {
 				return fmt.Errorf("removing node %d: %w", nodeID, err)
 			}
 

--- a/cli/rename.go
+++ b/cli/rename.go
@@ -88,7 +88,7 @@ func runRename(cmd *cobra.Command, args []string) error {
 	}
 
 	fid := fabricID()
-	node, err := getNodeForCompletion(fid, nodeID)
+	node, err := loadNodeForCompletion(fid, nodeID)
 	if err != nil {
 		return fmt.Errorf("looking up node %d: %w", nodeID, err)
 	}
@@ -133,7 +133,7 @@ func runRename(cmd *cobra.Command, args []string) error {
 	warnOnNameConflict(cmd, fid, nodeID, newName)
 
 	node.Name = newName
-	if err := saveNode(fid, node); err != nil {
+	if err := persistNode(fid, node); err != nil {
 		return fmt.Errorf("saving node: %w", err)
 	}
 
@@ -188,7 +188,7 @@ func validateNodeLabel(name string) error {
 // warnOnNameConflict prints a warning (but does not block) when another node
 // in the same fabric already has the same name.
 func warnOnNameConflict(cmd *cobra.Command, fabricID, nodeID uint64, name string) {
-	nodes, err := listNodesForCompletion(fabricID)
+	nodes, err := loadNodesForCompletion(fabricID)
 	if err != nil {
 		return
 	}

--- a/cli/tree.go
+++ b/cli/tree.go
@@ -67,7 +67,7 @@ func newTreeCmd() *cobra.Command {
 				fabricID = 1
 			}
 
-			node, err := getNodeForCompletion(fabricID, nodeID)
+			node, err := loadNodeForCompletion(fabricID, nodeID)
 			if err != nil {
 				return fmt.Errorf("getting node %d: %w", nodeID, err)
 			}

--- a/cli/use.go
+++ b/cli/use.go
@@ -142,7 +142,7 @@ func showCurrentTarget(cmd *cobra.Command) error {
 	if fid == 0 {
 		fid = 1
 	}
-	if node, err := getNodeForCompletion(fid, nodeID); err == nil && node.Name != "" {
+	if node, err := loadNodeForCompletion(fid, nodeID); err == nil && node.Name != "" {
 		fmt.Fprintf(w, "  %s %s %s\n",
 			output.Label("Device:"), output.Bold(node.Name),
 			output.Muted(fmt.Sprintf("(node %d)", nodeID)))

--- a/docs/DAEMON_STORE.md
+++ b/docs/DAEMON_STORE.md
@@ -4,14 +4,18 @@
 
 | Need | Helper to use |
 |------|---------------|
-| List all nodes | `listNodesForCompletion(fabricID)` |
-| Get a single node | `getNodeForCompletion(fabricID, nodeID)` |
-| Get fabric info | `getFabric(fabricID)` |
-| Save / update a node | `saveNode(fabricID, node)` |
+| List all nodes (raw) | `loadNodes(fabricID)` |
+| List all nodes (for completion) | `loadNodesForCompletion(fabricID)` |
+| Get a single node | `loadNodeForCompletion(fabricID, nodeID)` |
+| Get fabric info | `loadFabric(fabricID)` |
+| Save / update a node | `persistNode(fabricID, node)` |
+| Delete a node | `removeNode(fabricID, nodeID)` |
+
+The helpers use distinct verbs (`load*`, `persist*`, `remove*`) rather than mirroring the `store.Store` interface method names (`ListNodes`, `GetNode`, `SaveNode`, `DeleteNode`) so that a reader can tell at a glance whether code is calling the daemon-aware wrapper or the underlying store directly.
 
 These helpers call `daemon.NewClient("").IsRunning()` first. When the daemon is running they proxy the request through its Unix socket. When no daemon is running they open the DB directly.
 
-**Shell completion functions** (in `cli/completion/completer.go`) have an equivalent `listNodes(fabricID)` helper — use it instead of opening the store directly.
+**Shell completion functions** (in `cli/completion/completer.go`) have an equivalent `loadNodes(fabricID)` helper — use it instead of opening the store directly.
 
 **Commands that need exclusive write access** (e.g. commissioning) cannot be proxied through the daemon and must refuse early when the daemon is running:
 


### PR DESCRIPTION
## Summary

Rename the thin daemon-aware wrappers in `cli/device.go` so their names
no longer collide with `store.Store` interface methods. Stacked on top
of #57 (rename feature) — rebase onto `main` once that merges.

Renames:

| Before                   | After                    |
|--------------------------|--------------------------|
| `listNodes`              | `loadNodes`              |
| `listNodesForCompletion` | `loadNodesForCompletion` |
| `getNodeForCompletion`   | `loadNodeForCompletion`  |
| `getFabric`              | `loadFabric`             |
| `saveNode`               | `persistNode`            |
| `deleteNode`             | `removeNode`             |

Same refactor applied to `cli/completion/completer.go`'s local
`listNodes` → `loadNodes`.

## Why

The wrappers proxy through the session daemon when it's running and open
BoltDB directly otherwise. Sharing names with `store.Store` methods
(`ListNodes`, `GetNode`, `SaveNode`, `DeleteNode`) made reading hard:
`saveNode(...)` vs `s.SaveNode(...)` in the same file was confusing, and
`saveNode` had in fact been removed once already as "apparently unused"
before (`d2315ef`) — distinct verbs make it obvious which layer you're
calling.

Docs (`docs/DAEMON_STORE.md`) updated with the new table and a short
note explaining the naming convention.

## Test plan

- [x] `go build ./...` passes
- [x] `mise run test` passes
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)